### PR TITLE
Add `config.param_sep` support for admin panel (this fixes #30, #36; see #39)

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -180,7 +180,7 @@ class AdminPlugin extends Plugin
         // Replace page service with admin.
         $this->grav['page'] = function () use ($self) {
             $page = new Page;
-            $page->init(new \SplFileInfo(str_ireplace('task:', '',__DIR__ . "/pages/admin/{$self->template}.md")));
+            $page->init(new \SplFileInfo(__DIR__ . "/pages/admin/{$self->template}.md"));
             $page->slug(basename($self->template));
             return $page;
         };

--- a/admin.php
+++ b/admin.php
@@ -180,7 +180,7 @@ class AdminPlugin extends Plugin
         // Replace page service with admin.
         $this->grav['page'] = function () use ($self) {
             $page = new Page;
-            $page->init(new \SplFileInfo(__DIR__ . "/pages/admin/{$self->template}.md"));
+            $page->init(new \SplFileInfo(str_ireplace('task:', '',__DIR__ . "/pages/admin/{$self->template}.md")));
             $page->slug(basename($self->template));
             return $page;
         };

--- a/classes/controller.php
+++ b/classes/controller.php
@@ -151,7 +151,7 @@ class AdminController
 
         $this->admin->session()->invalidate()->start();
         $this->admin->setMessage($l->translate('LOGGED_OUT'), 'info');
-        $this->setRedirect('/');
+        $this->setRedirect('/logout');
 
         return true;
     }

--- a/pages/admin/logout.md
+++ b/pages/admin/logout.md
@@ -1,0 +1,14 @@
+---
+title: Dashboard Logout
+
+form:
+    fields:
+        - name: username
+          type: text
+          placeholder: Username
+          autofocus: true
+
+        - name: password
+          type: password
+          placeholder: Password
+---

--- a/themes/grav/js/admin-all.js
+++ b/themes/grav/js/admin-all.js
@@ -123,13 +123,14 @@ $(function () {
 
         $(this).attr('disabled','disabled').find('> .fa').removeClass('fa-cloud-download').addClass('fa-refresh fa-spin');
         var url = $(this).data('maintenanceUpdate');
+        var task = 'task' + GravAdmin.config.param_sep;
 
         GravAjax({
             dataType: "json",
             url: url,
             toastErrors: true,
             success: function(result, status) {
-                if (url.indexOf('task:updategrav') !== -1) {
+                if (url.indexOf(task + 'updategrav') !== -1) {
                     if (result.status == 'success') {
                         $('[data-gpm-grav]').remove();
                         toastr.success(result.message + window.grav_available_version);
@@ -181,6 +182,7 @@ $(function () {
             url: url,
             toastErrors: true,
             success: function(result, status) {
+                var task = 'task' + GravAdmin.config.param_sep;
 
                 var toastrBackup = {};
                 if (result.toastr) {
@@ -198,7 +200,7 @@ $(function () {
                     }
                 }
 
-                if (url.indexOf('task:backup') !== -1) {
+                if (url.indexOf(task + 'backup') !== -1) {
                     //Reset backup days count
                     $('.backups-chart .numeric').html("0 <em>days</em>");
 
@@ -255,13 +257,14 @@ $(function () {
             success: function (response) {
                 var grav = response.payload.grav,
                     installed = response.payload.installed,
-                    resources = response.payload.resources;
+                    resources = response.payload.resources,
+                    task = 'task' + GravAdmin.config.param_sep;
 
                 // grav updatable
                 if (grav.isUpdatable) {
                     var icon    = '<i class="fa fa-bullhorn"></i> ';
                         content = 'Grav <b>v{available}</b> is now available! <span class="less">(Current: v{version})</span> ',
-                        button  = '<button data-maintenance-update="' + GravAdmin.config.base_url_relative + '/update.json/task:updategrav" class="button button-small secondary" id="grav-update-button">Update Grav Now</button>';
+                        button  = '<button data-maintenance-update="' + GravAdmin.config.base_url_relative + '/update.json/' + task + 'updategrav" class="button button-small secondary" id="grav-update-button">Update Grav Now</button>';
 
                     if (grav.isSymlink) {
                         button = '<span class="hint--left" style="float: right;" data-hint="Grav is symbolically linked. Upgrade won\'t be available."><i class="fa fa-fw fa-link"></i></span>';
@@ -293,7 +296,7 @@ $(function () {
                     var length,
                         icon = '<i class="fa fa-bullhorn"></i>',
                         content = '{updates} of your {type} have an <strong>update available</strong>',
-                        button = '<a href="{location}/task:update" class="button button-small secondary">Update {Type}</a>',
+                        button = '<a href="{location}/' + task + 'update" class="button button-small secondary">Update {Type}</a>',
                         plugins = $('.grav-update.plugins'),
                         themes = $('.grav-update.themes'),
                         sidebar = {plugins: $('#admin-menu a[href$="/plugins"]'), themes: $('#admin-menu a[href$="/themes"]')};

--- a/themes/grav/js/mdeditor.js
+++ b/themes/grav/js/mdeditor.js
@@ -36,7 +36,8 @@
     ].join('');
 
     var MDEditor = function(editor, options){
-        var tpl = template, $this = this;
+        var tpl = template, $this = this,
+            task = 'task' + GravAdmin.config.param_sep;
 
         this.defaults = {
             markdown     : false,
@@ -93,7 +94,7 @@
                     if ($(this).hasClass('grav-mdeditor-button-preview')) {
                         GravAjax({
                             dataType: 'JSON',
-                            url: $this.element.data('grav-urlpreview') + '/task:processmarkdown',
+                            url: $this.element.data('grav-urlpreview') + '/' + task + 'processmarkdown',
                             method: 'post',
                             data: $this.element.parents('form').serialize(),
                             toastErrors: true,

--- a/themes/grav/js/pages-all.js
+++ b/themes/grav/js/pages-all.js
@@ -76,6 +76,7 @@ $(function(){
     restoreStates();
 
     var startFilterPages = function () {
+        var task = 'task' + GravAdmin.config.param_sep;
 
         $('input[name="page-search"]').focus();
         var flags = $('input[name="page-filter"]').val(),
@@ -89,7 +90,7 @@ $(function(){
         GravAjax({
             dataType: 'json',
             method: 'POST',
-            url: GravAdmin.config.base_url_relative + '/pages-filter.json/task:filterPages',
+            url: GravAdmin.config.base_url_relative + '/pages-filter.json/' + task + 'filterPages',
             data: {
                 flags: flags,
                 query: query

--- a/themes/grav/templates/dashboard.html.twig
+++ b/themes/grav/templates/dashboard.html.twig
@@ -3,15 +3,15 @@
 {% block titlebar %}
     <div class="button-bar">
         <div class="button-group">
-            <button data-clear-cache="{{ base_url_relative }}/cache.json/task:clearCache" class="button"><i class="fa fa-trash"></i> Clear Cache</button>
+            <button data-clear-cache="{{ base_url_relative }}/cache.json/task{{ config.system.param_sep }}clearCache" class="button"><i class="fa fa-trash"></i> Clear Cache</button>
             <button type="button" class="button dropdown-toggle" data-toggle="dropdown">
                 <i class="fa fa-caret-down"></i>
             </button>
             <ul class="dropdown-menu">
-                <li><a data-clear-cache="{{ base_url_relative }}/cache.json/task:clearCache/cleartype:all" href="#">All Cache</a></li>
-                <li><a data-clear-cache="{{ base_url_relative }}/cache.json/task:clearCache/cleartype:assets-only" href="#">Assets Only</a></li>
-                <li><a data-clear-cache="{{ base_url_relative }}/cache.json/task:clearCache/cleartype:images-only" href="#">Images Only</a></li>
-                <li><a data-clear-cache="{{ base_url_relative }}/cache.json/task:clearCache/cleartype:cache-only" href="#">Cache Only</a></li>
+                <li><a data-clear-cache="{{ base_url_relative }}/cache.json/task{{ config.system.param_sep }}clearCache/cleartype:all" href="#">All Cache</a></li>
+                <li><a data-clear-cache="{{ base_url_relative }}/cache.json/task{{ config.system.param_sep }}clearCache/cleartype:assets-only" href="#">Assets Only</a></li>
+                <li><a data-clear-cache="{{ base_url_relative }}/cache.json/task{{ config.system.param_sep }}clearCache/cleartype:images-only" href="#">Images Only</a></li>
+                <li><a data-clear-cache="{{ base_url_relative }}/cache.json/task{{ config.system.param_sep }}clearCache/cleartype:cache-only" href="#">Cache Only</a></li>
             </ul>
         </div>
         <button data-gpm-checkupdates="" class="button"><i class="fa fa-refresh"></i> Check for Updates</button>
@@ -62,8 +62,8 @@
                     </div>
                 </div>
                 <div class="flush-bottom button-bar">
-                    <button data-maintenance-update="{{ base_url_relative }}/update.json/task:update" class="button"><i class="fa fa-cloud-download"></i> Update</button>
-                    <button data-ajax="{{ base_url_relative }}/backup.json/task:backup" class="button"><i class="fa fa-database"></i> Backup</button>
+                    <button data-maintenance-update="{{ base_url_relative }}/update.json/task{{ config.system.param_sep }}update" class="button"><i class="fa fa-cloud-download"></i> Update</button>
+                    <button data-ajax="{{ base_url_relative }}/backup.json/task{{ config.system.param_sep }}backup" class="button"><i class="fa fa-database"></i> Backup</button>
                 </div>
             </div>
         </div>

--- a/themes/grav/templates/denied.html.twig
+++ b/themes/grav/templates/denied.html.twig
@@ -8,7 +8,7 @@
 
         {% include 'partials/messages.html.twig' %}
 
-        <p>{{ admin.user.fullname }}, your account does not have administrator permissions. <a href="{{ base_url_relative }}/task:logout">Logout</a></p>
+        <p>{{ admin.user.fullname }}, your account does not have administrator permissions. <a href="{{ base_url_relative }}/task{{ config.system.param_sep }}logout">Logout</a></p>
     </div>
 {% endblock %}
 

--- a/themes/grav/templates/forms/fields/uploads/uploads.html.twig
+++ b/themes/grav/templates/forms/fields/uploads/uploads.html.twig
@@ -60,7 +60,7 @@
                     previewTemplate: "<div class=\"dz-preview dz-file-preview\">\n  <div class=\"dz-details\">\n    <div class=\"dz-filename\"><span data-dz-name></span></div>\n    <div class=\"dz-size\" data-dz-size></div>\n    <img data-dz-thumbnail />\n  </div>\n  <div class=\"dz-progress\"><span class=\"dz-upload\" data-dz-uploadprogress></span></div>\n  <div class=\"dz-success-mark\"><span>✔</span></div>\n  <div class=\"dz-error-mark\"><span>✘</span></div>\n  <div class=\"dz-error-message\"><span data-dz-errormessage></span></div>\n<a class=\"dz-remove\" href=\"javascript:undefined;\" data-dz-remove>Delete</a>\n<a class=\"dz-insert\" href=\"javascript:undefined;\" data-dz-insert>Insert</a>\n</div>",
                     init: function() {
                         thisDropzone = this;
-                        $.get(URI + '/task:listmedia', function(data) {
+                        $.get(URI + '/task{{ config.system.param_sep }}listmedia', function(data) {
 
                             $.proxy(modalError, this, {
                                 data: data,
@@ -106,7 +106,7 @@
                         this.on('removedfile', function(file) {
                             if (!file.accepted || file.rejected) return;
                             thisDropzone = this;
-                            $.post(URI + '/task:delmedia', {filename: file.name}, function(data){
+                            $.post(URI + '/task{{ config.system.param_sep }}delmedia', {filename: file.name}, function(data){
                                 $.proxy(modalError, thisDropzone, {
                                     file: file,
                                     data: data,
@@ -118,7 +118,7 @@
                     }
                 };
 
-                var dropzone = new Dropzone("#gravDropzone", { url: URI + '/task:addmedia', createImageThumbnails: { thumbnailWidth: 150} });
+                var dropzone = new Dropzone("#gravDropzone", { url: URI + '/task{{ config.system.param_sep }}addmedia', createImageThumbnails: { thumbnailWidth: 150} });
 
                 $("#gravDropzone").delegate('.dz-preview', 'dragstart', function(e){
                     var uri = $(this).find('.dz-filename').text(), shortcode = '![](' + encodeURI(uri) + ')';

--- a/themes/grav/templates/logout.html.twig
+++ b/themes/grav/templates/logout.html.twig
@@ -1,0 +1,17 @@
+{% extends 'partials/base.html.twig' %}
+
+{% block head %}
+    {{ parent() }}
+    <meta http-equiv="refresh" content="5; URL={{ base_url_relative }}">
+{% endblock %}
+
+{% block page %}
+<section id="admin-login" class="default-glow-shadow">
+    <h1>
+        {{ title }}
+    </h1>
+
+    <div class="info alert">{{ 'LOGGED_OUT'|t }}</div>
+    {% include 'partials/messages.html.twig' %}
+</section>
+{% endblock %}

--- a/themes/grav/templates/logout.html.twig
+++ b/themes/grav/templates/logout.html.twig
@@ -1,17 +1,17 @@
-{% extends 'partials/base.html.twig' %}
-
-{% block head %}
+{% embed 'partials/login.html.twig' with {title:'Grav Logout'} %}
+  {% block head %}
     {{ parent() }}
-    <meta http-equiv="refresh" content="5; URL={{ base_url_relative }}">
-{% endblock %}
+    <meta http-equiv="refresh" content="3; URL={{ base_url_relative }}">
+  {% endblock %}
 
-{% block page %}
-<section id="admin-login" class="default-glow-shadow">
-    <h1>
-        {{ title }}
-    </h1>
+  {% block page %}
+    <section id="admin-login" class="default-glow-shadow">
+        <h1>
+            {{ title }}
+        </h1>
 
-    <div class="info alert">{{ 'LOGGED_OUT'|t }}</div>
-    {% include 'partials/messages.html.twig' %}
-</section>
-{% endblock %}
+        <div class="info alert">{{ 'LOGGED_OUT'|t }}</div>
+        {% include 'partials/messages.html.twig' %}
+    </section>
+    {% endblock %}
+{% endembed %}

--- a/themes/grav/templates/pages.html.twig
+++ b/themes/grav/templates/pages.html.twig
@@ -54,9 +54,9 @@
                 <span class="page-home">{{ p.home ? '<i class="fa fa-home"></i>' }}</span>
                 <span class="page-tools">
                     {% if warn %}
-                    <a href="#delete" data-remodal-target="delete" data-delete-url="{{ base_url }}/pages/{{ p.route|trim('/') }}/task:delete" class="page-delete" ><i class="fa fa-close"></i></a>
+                    <a href="#delete" data-remodal-target="delete" data-delete-url="{{ base_url }}/pages/{{ p.route|trim('/') }}/task{{ config.system.param_sep }}delete" class="page-delete" ><i class="fa fa-close"></i></a>
                     {% else %}
-                    <a href="{{ base_url }}/pages/{{ p.route|trim('/') }}/task:delete" class="page-delete" ><i class="fa fa-close"></i></a>
+                    <a href="{{ base_url }}/pages/{{ p.route|trim('/') }}/task{{ config.system.param_sep }}delete" class="page-delete" ><i class="fa fa-close"></i></a>
                     {% endif %}
                 </span>
                 <p class="page-route">{{ p.route }}</p>
@@ -81,12 +81,12 @@
         {% elseif mode == 'edit' %}
             <a class="button" href="{{ base_url }}/pages"><i class="fa fa-reply"></i> Back</a>
             {% if exists %}
-                <a class="button" href="{{ uri.route(true) }}/task:copy" class="page-copy" ><i class="fa fa-copy"></i> Copy</a>
+                <a class="button" href="{{ uri.route(true) }}/task{{ config.system.param_sep }}copy" class="page-copy" ><i class="fa fa-copy"></i> Copy</a>
                 <a class="button" href="#" data-remodal-target="move"><i class="fa fa-arrows"></i> Move</a>
                 {% if warn %}
-                    <a class="button" href="#delete" data-remodal-target="delete" data-delete-url="{{ uri.route(true) }}/task:delete"><i class="fa fa-close"></i> Delete</a>
+                    <a class="button" href="#delete" data-remodal-target="delete" data-delete-url="{{ uri.route(true) }}/task{{ config.system.param_sep }}delete"><i class="fa fa-close"></i> Delete</a>
                 {% else %}
-                    <a class="button" href="{{ uri.route(true) }}/task:delete" class="page-delete" ><i class="fa fa-close"></i></a>
+                    <a class="button" href="{{ uri.route(true) }}/task{{ config.system.param_sep }}delete" class="page-delete" ><i class="fa fa-close"></i></a>
                 {% endif %}
             {% endif %}
             <button class="button" name="task" value="save" form="blueprints"><i class="fa fa-check"></i> Save</button>

--- a/themes/grav/templates/partials/javascript-config.html.twig
+++ b/themes/grav/templates/partials/javascript-config.html.twig
@@ -1,6 +1,7 @@
 <script type="text/javascript">
 	window.GravAdmin = window.GravAdmin || {};
 	window.GravAdmin.config = {
-		base_url_relative: '{{ base_url_relative }}'
+		base_url_relative: '{{ base_url_relative }}',
+    param_sep: '{{ config.system.param_sep }}'
 	};
 </script>

--- a/themes/grav/templates/partials/nav.html.twig
+++ b/themes/grav/templates/partials/nav.html.twig
@@ -62,7 +62,7 @@
             </a>
         </li> -->
         <li>
-            <a href="{{ base_url_relative }}/task:logout"><i class="fa fa-fw fa-sign-out"></i> Logout</a>
+            <a href="{{ base_url_relative }}/task{{ config.system.param_sep }}logout"><i class="fa fa-fw fa-sign-out"></i> Logout</a>
         </li>
     </ul>
 </nav>

--- a/themes/grav/templates/partials/plugins-details.html.twig
+++ b/themes/grav/templates/partials/plugins-details.html.twig
@@ -35,10 +35,10 @@
 
     <div class="button-bar danger">
         <span class="danger-zone"></span>
-        <a class="button" href="{{ base_url_relative }}/plugins/{{ plugin.slug }}/task:uninstall"><i class="fa fa-fw fa-warning"></i>Remove Plugin</a>
+        <a class="button" href="{{ base_url_relative }}/plugins/{{ plugin.slug }}/task{{ config.system.param_sep }}uninstall"><i class="fa fa-fw fa-warning"></i>Remove Plugin</a>
     </div>
 {% else %}
     <div class="button-bar success">
-        <a class="button" href="{{ base_url_relative }}/plugins/{{ plugin.slug }}/task:install"><i class="fa fa-fw fa-plus"></i>Install Plugin</a>
+        <a class="button" href="{{ base_url_relative }}/plugins/{{ plugin.slug }}/task{{ config.system.param_sep }}install"><i class="fa fa-fw fa-plus"></i>Install Plugin</a>
     </div>
 {% endif %}

--- a/themes/grav/templates/partials/plugins-list.html.twig
+++ b/themes/grav/templates/partials/plugins-list.html.twig
@@ -25,11 +25,11 @@
             </td>
             <td class="gpm-actions">
                 {% if (not installing and plugin.form.fields.enabled and (plugin.form.fields.enabled.type != 'hidden')) %}
-                    <a class="{{ data.get('enabled') ? 'enabled' : 'disabled' }}" href="{{ base_url_relative }}/plugins/{{ slug }}/task:{{ data.get('enabled') ? 'disable' : 'enable' }}">
+                    <a class="{{ data.get('enabled') ? 'enabled' : 'disabled' }}" href="{{ base_url_relative }}/plugins/{{ slug }}/task{{ config.system.param_sep }}{{ data.get('enabled') ? 'disable' : 'enable' }}">
                         <i class="fa fa-fw fa-toggle-{{ data.get('enabled') ? 'on' : 'off' }}"></i>
                     </a>
                 {% elseif (installing) %}
-                    <a class="button" href="{{ base_url_relative }}/plugins/{{ slug }}/task:install"><i class="fa fa-plus"></i> Install</a>
+                    <a class="button" href="{{ base_url_relative }}/plugins/{{ slug }}/task{{ config.system.param_sep }}install"><i class="fa fa-plus"></i> Install</a>
                 {% endif %}
                 <span class="gpm-details-expand"><i class="fa fa-chevron-down"></i></span>
             </td>

--- a/themes/grav/templates/partials/themes-details.html.twig
+++ b/themes/grav/templates/partials/themes-details.html.twig
@@ -102,12 +102,12 @@
     {% if (config.get('system.pages.theme') != admin.route) %}
     <div class="button-bar danger">
         <span class="danger-zone"></span>
-        <a class="button" href="{{ base_url_relative }}/themes/{{ theme.slug }}/task:uninstall"><i class="fa fa-fw fa-warning"></i>Remove Theme</a>
+        <a class="button" href="{{ base_url_relative }}/themes/{{ theme.slug }}/task{{ config.system.param_sep }}uninstall"><i class="fa fa-fw fa-warning"></i>Remove Theme</a>
     </div>
     {% endif %}
 {% else %}
     <div class="button-bar success">
-        <a class="button" href="{{ base_url_relative }}/themes/{{ theme.slug }}/task:install"><i class="fa fa-fw fa-plus"></i>Install Theme</a>
+        <a class="button" href="{{ base_url_relative }}/themes/{{ theme.slug }}/task{{ config.system.param_sep }}install"><i class="fa fa-fw fa-plus"></i>Install Theme</a>
     </div>
 {% endif %}
 

--- a/themes/grav/templates/partials/themes-list.html.twig
+++ b/themes/grav/templates/partials/themes-list.html.twig
@@ -31,15 +31,15 @@
             </div>
             {% if (state == 'installing') %}
                 <div class="gpm-actions">
-                    <a class="button" href="{{ base_url_relative }}/themes/{{ slug }}/task:install"><i class="fa fa-plus"></i> Install</a>
+                    <a class="button" href="{{ base_url_relative }}/themes/{{ slug }}/task{{ config.system.param_sep }}install"><i class="fa fa-plus"></i> Install</a>
                 </div>
             {% elseif state == 'active' %}
                 <div class="gpm-actions">
                     <i class="fa fa-star"></i> Active Theme
                 </div>
             {% else %}
-                <a data-remodal-target="theme-switch-warn" href="{{ base_url_relative }}/themes/{{ slug }}/task:activate" class="gpm-actions">
-                    {# <a class="disabled" href="{{ base_url_relative }}/themes/{{ slug }}/task:activate"><i class="fa fa-fw fa-toggle-off"></i></a> #}
+                <a data-remodal-target="theme-switch-warn" href="{{ base_url_relative }}/themes/{{ slug }}/task{{ config.system.param_sep }}activate" class="gpm-actions">
+                    {# <a class="disabled" href="{{ base_url_relative }}/themes/{{ slug }}/task{{ config.system.param_sep }}activate"><i class="fa fa-fw fa-toggle-off"></i></a> #}
                     Activate
                 </a>
             {% endif %}

--- a/themes/grav/templates/partials/toolbar.html.twig
+++ b/themes/grav/templates/partials/toolbar.html.twig
@@ -10,6 +10,6 @@
 
 {% if admin.authorise %}
 <span class="user-details">
-<img src="http://www.gravatar.com/avatar/{{ admin.user.email|md5 }}?s=50" /><span class="badge">6</span><span class="hide-small">Hi, {{ admin.user.fullname }}<span> <a href="{{ base_url_relative }}/task:logout">Logout</a>
+<img src="http://www.gravatar.com/avatar/{{ admin.user.email|md5 }}?s=50" /><span class="badge">6</span><span class="hide-small">Hi, {{ admin.user.fullname }}<span> <a href="{{ base_url_relative }}/task{{ config.system.param_sep }}logout">Logout</a>
 </span>
 {% endif %}


### PR DESCRIPTION
This is a fix for #30. Here the admin route was broken due to included `task:` and a logout page and a theme template missing.

**UPDATE**: It turned out that the route wasn't the problem, but actually a windows specific setting, namely `system.config_sep: "+"`, which was not correctly implemented in the admin theme templates..