### PR TITLE
Fix for issue 48

### DIFF
--- a/themes/grav/templates/forms/fields/order/order.html.twig
+++ b/themes/grav/templates/forms/fields/order/order.html.twig
@@ -22,11 +22,15 @@
                 <span class="note">Page is not visible, ordering disabled</span>
             {% endif %}
 
-            <ul id="ordering" class="{{ field.classes }}">
-                {% for page in siblings %}
-                <li class="{% if page.order  == value %}drag-handle{% else %}ignore{% endif %}" data-id="{{ page.slug }}">{{ page.title() }}</li>
+            {% if siblings|length < 200 %}
+				<ul id="ordering" class="{{ field.classes }}">
+			    {% for page in siblings %}
+					<li class="{% if page.order  == value %}drag-handle{% else %}ignore{% endif %}" data-id="{{ page.slug }}">{{ page.title() }}</li>
                 {% endfor %}
-            </ul>
+				</ul>
+			{% else %}
+				Your list contains more than 200 elements and is therefore not displayed to avoid technical problems.
+			{% endif %}
         </div>
     </div>
     <script type="text/javascript" src="{{ base_url_relative_frontend }}{{ theme_url }}/js/sortable.min.js"></script>


### PR DESCRIPTION
If the list of posts is larger than 200 there might be technical problems when trying to edit a page, as seen in issue #48 . Therefore ordering is only available if the amount of post is less than 200.