### PR TITLE
Fix missing dollar sign

### DIFF
--- a/classes/controller.php
+++ b/classes/controller.php
@@ -517,7 +517,7 @@ class AdminController
 
         $grav_limit = $config->get('system.media.upload_limit', 0);
         // You should also check filesize here.
-        if ($grav_limit > 0 && $_FILES['file']['size'] > grav_limit) {
+        if ($grav_limit > 0 && $_FILES['file']['size'] > $grav_limit) {
             $this->admin->json_response = ['status' => 'error', 'message' => $this->admin->translate('PLUGIN_ADMIN.EXCEEDED_GRAV_FILESIZE_LIMIT')];
             return;
         }


### PR DESCRIPTION
grav_limit was a constant when it should be a variable. Causes a warning and bug when file_limit is set to something other than zero and you upload a file.