### PR TITLE
Feature/allow plugins hook in admin

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -223,6 +223,9 @@ class AdminPlugin extends Plugin
         $twig->twig_vars['base_path'] = GRAV_ROOT;
         $twig->twig_vars['admin'] = $this->admin;
 
+        // Gather Plugin-hooked nav items
+        $this->grav->fireEvent('onAdminTemplateNavPluginHook');
+
         switch ($this->template) {
             case 'dashboard':
                 $twig->twig_vars['popularity'] = $this->popularity;

--- a/admin.php
+++ b/admin.php
@@ -182,9 +182,29 @@ class AdminPlugin extends Plugin
         // Replace page service with admin.
         $this->grav['page'] = function () use ($self) {
             $page = new Page;
-            $page->init(new \SplFileInfo(__DIR__ . "/pages/admin/{$self->template}.md"));
-            $page->slug(basename($self->template));
-            return $page;
+
+            if (file_exists(__DIR__ . "/pages/admin/{$self->template}.md")) {
+                $page->init(new \SplFileInfo(__DIR__ . "/pages/admin/{$self->template}.md"));
+                $page->slug(basename($self->template));
+                return $page;
+            }
+
+            // If the page cannot be found, try looking in plugins.
+            // Allows pages added by plugins in admin
+            $plugins = Grav::instance()['config']->get('plugins', []);
+
+            foreach($plugins as $plugin => $data) {
+                $folder = GRAV_ROOT . "/user/plugins/" . $plugin . "/admin";
+
+                if (file_exists($folder)) {
+                    $file = $folder . "/pages/{$self->template}.md";
+                    if (file_exists($file)) {
+                        $page->init(new \SplFileInfo($file));
+                        $page->slug(basename($self->template));
+                        return $page;
+                    }
+                }
+            }
         };
     }
 

--- a/themes/grav/templates/partials/nav.html.twig
+++ b/themes/grav/templates/partials/nav.html.twig
@@ -31,6 +31,15 @@
                 </span>
             </a>
         </li>
+        {% if grav.twig.plugins_hooked_nav %}
+            {% for label, item in grav.twig.plugins_hooked_nav %}
+                <li class="{{ (location == item.route) ? 'selected' : '' }}">
+                    <a href="{{ base_url_relative }}/{{ item.route }}">
+                        <i class="fa fa-fw {{ item.icon }}"></i> {{ label|tu }}
+                    </a>
+                </li>
+            {% endfor %}
+        {% endif %}
         <li class="{{ (location == 'plugins') ? 'selected' : '' }}">
             <a href="{{ base_url_relative }}/plugins">
                 <i class="fa fa-fw fa-plug"></i> {{ "PLUGIN_ADMIN.PLUGINS"|tu }}


### PR DESCRIPTION
Adds 

1) the possibility for a plugin to provide pages to be used by the admin plugin

2) the ability to hook in the nav menu with the onAdminTemplateNavPluginHook event.

Example usage:

```
    public function onAdminTemplateNavPluginHook()
    {
        $this->grav['twig']->plugins_hooked_nav['PLUGIN_DATA.DATA'] = ['route' => 'data', 'icon' => 'fa-file-text'];
    }
```
