### PR TITLE
Reduce complexity of Install/Uninstall gpm action

### DIFF
--- a/themes/grav/templates/partials/plugins-list.html.twig
+++ b/themes/grav/templates/partials/plugins-list.html.twig
@@ -23,7 +23,7 @@
                 <span class="gpm-version">v{{ plugin.version }}</span>
             </td>
             <td class="gpm-actions">
-                {% if (not installing and plugin.form.fields.enabled and (plugin.form.fields.enabled.type != 'hidden')) %}
+                {% if (not installing and (plugin.form.fields.enabled.type != 'hidden')) %}
                     <a class="{{ data.get('enabled') ? 'enabled' : 'disabled' }}" href="{{ base_url_relative }}/plugins/{{ slug }}/task{{ config.system.param_sep }}{{ data.get('enabled') ? 'disable' : 'enable' }}">
                         <i class="fa fa-fw fa-toggle-{{ data.get('enabled') ? 'on' : 'off' }}"></i>
                     </a>


### PR DESCRIPTION
This PR reduces the complexity of checking the visibility status of the GPM action "Install/Uninstall". This action field is only hidden on those plugins with a `enabled.type: hidden` field and shown otherwise. This PR especially accounts for plugins which have an `enabled: true` property, but their `enabled` option in the blueprint is located elsewhere (e.g. wrapped in a section field).