### PR TITLE
Added options field into pages

### DIFF
--- a/themes/grav/templates/forms/fields/pages/pages.html.twig
+++ b/themes/grav/templates/forms/fields/pages/pages.html.twig
@@ -2,6 +2,12 @@
 
 {% macro options(field, pages, value, depth) %}
 
+    {% if field.options and depth == 0 %}
+        {% for key, value in field.options %}
+            <option value="{{ key | e('html_attr') }}">{{ value }}</option>
+        {% endfor %}
+    {% endif %}
+    
     {% if field.show_root and depth == 0 %}
         <option value="/">/ (Root)</option>
         {% set depth = depth +1 %}


### PR DESCRIPTION
This is important when we used into plugin for select one page, but if not used this every time we update one page (where we not need to setup this field) the field is saved into the page.

With this we use at the same of normal select so we can use the empty key with default text.