### PR TITLE
#188: Use relative URLs for the login form action URL.

### DIFF
--- a/themes/grav/templates/partials/login.html.twig
+++ b/themes/grav/templates/partials/login.html.twig
@@ -8,7 +8,7 @@
 
         {% include 'partials/messages.html.twig' %}
 
-        <form method="post" action="{{ uri.url }}">
+        <form method="post" action="{{ base_url_relative }}">
             {% block form %}{% endblock %}
         </form>
     </section>


### PR DESCRIPTION
This fixes https://github.com/getgrav/grav-plugin-admin/issues/188