### PR TITLE
Adresses #205 and better find out link for plugin `README.md`

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -9,6 +9,7 @@ author:
 homepage: https://github.com/getgrav/grav-plugin-admin
 keywords: admin, plugin, manager, panel
 bugs: https://github.com/getgrav/grav-plugin-admin/issues
+readme: https://github.com/getgrav/grav-plugin-admin/blob/develop/README.md
 license: MIT
 
 dependencies:

--- a/themes/grav/templates/partials/plugin-data.html.twig
+++ b/themes/grav/templates/partials/plugin-data.html.twig
@@ -53,7 +53,7 @@
     {% endif %}
 
     {% if plugin.readme or plugin.homepage %}
-        {% set readme_link = plugin.readme ?: plugin.homepage ~ '/blob/develop/README.md' %}
+        {% set readme_link = plugin.readme ?: plugin.docs|default(plugin.homepage ~ '/blob/master/README.md') %}
         <tr>
             <td>{{ "PLUGIN_ADMIN.README"|tu }}:</td>
             <td><a href="{{ readme_link }}" target="_blank">{{ readme_link }}</a></td>


### PR DESCRIPTION
This PR addresses #205 and fix possibly broken README links. Further if there is no README link found, it will use the one provided in the `docs` option (used by getgrav.org anyway) and fallbacks to the master branch if any other thing fails.