### PR TITLE
Minor improvements

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -195,6 +195,16 @@ class AdminPlugin extends Plugin
             $plugins = Grav::instance()['config']->get('plugins', []);
 
             foreach($plugins as $plugin => $data) {
+                $path = $locator->findResource(
+                    "user://plugins/{$plugin}/pages/admin/{$self->template}.md");
+
+                if (file_exists($path)) {
+                    $page->init(new \SplFileInfo($path));
+                    $page->slug(basename($self->template));
+                    return $page;
+                }
+
+                // DEPRECATED: Will be removed!
                 $folder = GRAV_ROOT . "/user/plugins/" . $plugin . "/admin";
 
                 if (file_exists($folder)) {
@@ -245,6 +255,9 @@ class AdminPlugin extends Plugin
         $twig->twig_vars['admin'] = $this->admin;
 
         // Gather Plugin-hooked nav items
+        $this->grav->fireEvent('onAdminMenu');
+
+        // DEPRECATED
         $this->grav->fireEvent('onAdminTemplateNavPluginHook');
 
         switch ($this->template) {


### PR DESCRIPTION
This PR improves resolving (plugin dependent) admin pages using the stream locator instead of a hardcoded file path (to make it multisite capable!). Further it changes the location where admin pages have to be placed in a plugin. Currently on pages of plugin are picked up, when they are in the `user/plugins/<plugin>/admin/pages` folder. With this PR the location of admin pages changes to e.g. `user/plugins/<plugin>/pages/admin` (note the change in the last two parts to conform to the admin page structure of the admin plugin).

Further I'd like to rename the hook `onAdminTemplateNavPluginHook` to `onAdminMenu`, which is shorter and does not look cumbersome. To be honest this is a matter of taste. If you don't like, I'll will delete it back.

All my changes are backward-compatible. Once you are sure, that nobody uses the deprecated functions/page structure, you can delete them.
