### PR TITLE
Hide "Latest Pages" if there aren't any pages available

### DIFF
--- a/themes/grav/templates/dashboard.html.twig
+++ b/themes/grav/templates/dashboard.html.twig
@@ -142,7 +142,7 @@
             </div>
             <h1>{{ "PLUGIN_ADMIN.LATEST_PAGE_UPDATES"|tu }}</h1>
             <table>
-            {% for latest in admin.latestPages %}
+            {% for latest in admin.latestPages if admin.latestPages %}
                 <tr><td class="double page-title"><a href="{{ base_url }}/pages/{{ latest.route|trim('/') }}"><i class="fa fa-fw fa-file-o"></i> {{ latest.title }}</a></td><td class="double page-route">{{ latest.route }}</td><td><b class="last-modified">{{ latest.modified|nicetime }}</b></td></tr>
             {% endfor %}
             </table>


### PR DESCRIPTION
This PR addresses a minor issue installing the admin plugin without having any pages in the `user/pages` directory. At the moment logging in yields to an error in `dashboard.html.twig` apparently because `admin.latestPages` returns null, which isn't iterable. This PR check the value and suppresses this issue.