### PR TITLE
Added missing data-grav-field=select to global attributes on pagemediaselect field template

### DIFF
--- a/themes/grav/templates/forms/fields/pagemediaselect/pagemediaselect.html.twig
+++ b/themes/grav/templates/forms/fields/pagemediaselect/pagemediaselect.html.twig
@@ -8,6 +8,7 @@
 
 {% block global_attributes %}
     data-grav-selectize="{{ (field.selectize is defined ? field.selectize : {})|json_encode()|e('html_attr') }}"
+    data-grav-field="select"
     {{ parent() }}
 {% endblock %}
 
@@ -37,5 +38,3 @@
         {% if admin.page.media.all is empty %}Add files through the page media, or by dropping them in the page folder{% endif %}
     {% endif %}
 {% endblock %}
-
-


### PR DESCRIPTION
I tried to use pagemediaselect field inside a Page form but data from this field were not retrivied by the AdminController. However, the themeselect field was working so I compared files and I got pagemediaselect working by adding this line :

```
data-grav-field="select"
```

inside the block "global_attributes" in the pagemediaselect.html.twig template.

I'm new to grav cms so I hope this is the right way to fix the issue I was facing.