### PR TITLE
Fix list ordering

### DIFF
--- a/themes/grav/js/admin-all.js
+++ b/themes/grav/js/admin-all.js
@@ -407,7 +407,7 @@ $(function () {
                 item.attr('data-collection-key', index);
 
                 var baseName = null;
-                baseNameParts = prefix.split('.');
+                var baseNameParts = prefix.split('.');
 
                 for (var part in baseNameParts) {
                     if (baseName == null) {

--- a/themes/grav/js/admin-all.js
+++ b/themes/grav/js/admin-all.js
@@ -405,8 +405,21 @@ $(function () {
 
                 item.attr('data-collection-item', item.attr('data-collection-item').replace(r, prefix + '.' + index));
                 item.attr('data-collection-key', index);
+
+                var baseName = null;
+                baseNameParts = prefix.split('.');
+
+                for (var part in baseNameParts) {
+                    if (baseName == null) {
+                        baseName = baseNameParts[part];
+                        continue;
+                    }
+                    baseName += '['+baseNameParts[part]+']';
+                }
+
                 item.find('[name]').each(function () {
-                    $(this).attr('name', $(this).attr('name').replace(r, prefix + '[' + index));
+                    var nameAttr = $(this).attr('name');
+                    $(this).attr('name', nameAttr.replace(baseName + '[' + currentIndex, baseName + '[' + index));
                 });
             }
 

--- a/themes/grav/templates/forms/fields/list/list.html.twig
+++ b/themes/grav/templates/forms/fields/list/list.html.twig
@@ -18,7 +18,7 @@
         <div class="form-list-wrapper {{ field.size }}" data-type="collection">
             <ul data-collection-holder="{{ name }}">
                 {% if field.fields %}
-                {% for key, val in value %}
+                {% for key, val in value|reverse %}
                     {% if array and (key matches '/^\\d+$/') == 0 %}
                         {% set array = false %}
                         {% set lastKey = -1 %}

--- a/themes/grav/templates/forms/fields/list/list.html.twig
+++ b/themes/grav/templates/forms/fields/list/list.html.twig
@@ -18,7 +18,7 @@
         <div class="form-list-wrapper {{ field.size }}" data-type="collection">
             <ul data-collection-holder="{{ name }}">
                 {% if field.fields %}
-                {% for key, val in value|reverse %}
+                {% for key, val in value %}
                     {% if array and (key matches '/^\\d+$/') == 0 %}
                         {% set array = false %}
                         {% set lastKey = -1 %}


### PR DESCRIPTION
This PR fixes list ordering functionnaly. Field names inside list items were not updated because of the regex that was searching for names like "header.fieldname.1" instead of "header[fieldname][1].