### PR TITLE
Fixed problem with detecting ctrl key on Windows

### DIFF
--- a/themes/grav/js/admin-all.js
+++ b/themes/grav/js/admin-all.js
@@ -527,7 +527,7 @@ $(function () {
     if (saveTask.length) {
         $(window).on('keydown', function(event) {
             var key = String.fromCharCode(event.which).toLowerCase();
-            if ((event.ctrlKey || event.metaKey) && key == 's') {
+            if ((event.which == 17 || event.metaKey) && key == 's') {
                 event.preventDefault();
                 saveTask.click();
             }


### PR DESCRIPTION
This contribution fixes an error that is probably related to jquery's bug - event.ctrlKey triggers not only ctrl but also right ALT key. That might cause some troubles for users with keyboard layouts that requires pressing `right alt + s` for inserting regional characters. I could recreate this issue only on Windows machines.

There's little snippet for those who would like to test this on different platforms:
```
<script src="https://code.jquery.com/jquery-git2.min.js"></script>
<script>
$(window).on('keydown', function(event) {
    if (event.which == 17) {
        alert("ctrl");
    }
    if (event.which == 18) {
        alert("alt");
    }
});
</script>
```