### PR TITLE
Updated taskSave to ensure route is prefixed with a forward slash

### DIFF
--- a/classes/controller.php
+++ b/classes/controller.php
@@ -1185,6 +1185,9 @@ class AdminController
             $route = !isset($data['route']) ? dirname($this->admin->route) : $data['route'];
             $obj = $this->admin->page(true);
 
+            // Ensure route is prefixed with a forward slash.
+            $route = '/' . ltrim($route, '/');
+
             if (isset($data['frontmatter']) && !$this->checkValidFrontmatter($data['frontmatter'])) {
                 $this->admin->setMessage($this->admin->translate('PLUGIN_ADMIN.INVALID_FRONTMATTER_COULD_NOT_SAVE'), 'error');
                 return false;


### PR DESCRIPTION
Came across this issue when attempting to add a modular page to my parent page.

`$route` would return the correct slug for the parent page, however without a leading forward slash, so it didn't match any of the routes within `$this->routes` resulting in the `$parent` object being `NULL` and throwing an exception.

When watching the `$pages->dispatch` method being called, all other routes were prefixed with a forward slash, so thought it would be best to always ensure the route being checked had a leading forward slash.