### PR TITLE
Use of translated strings for placeholder in forms.

### DIFF
--- a/pages/admin/forgot.md
+++ b/pages/admin/forgot.md
@@ -5,7 +5,6 @@ form:
     fields:
         - name: username
           type: text
-          placeholder: Username
+          placeholder: PLUGIN_ADMIN.USERNAME
           autofocus: true
 ---
-

--- a/pages/admin/login.md
+++ b/pages/admin/login.md
@@ -9,12 +9,10 @@ form:
     fields:
         - name: username
           type: text
-          placeholder: Username
+          placeholder: PLUGIN_ADMIN.USERNAME
           autofocus: true
 
         - name: password
           type: password
-          placeholder: Password
+          placeholder: PLUGIN_ADMIN.PASSWORD
 ---
-
-

--- a/pages/admin/logout.md
+++ b/pages/admin/logout.md
@@ -5,10 +5,10 @@ form:
     fields:
         - name: username
           type: text
-          placeholder: Username
+          placeholder: PLUGIN_ADMIN.USERNAME
           autofocus: true
 
         - name: password
           type: password
-          placeholder: Password
+          placeholder: PLUGIN_ADMIN.PASSWORD
 ---

--- a/pages/admin/reset.md
+++ b/pages/admin/reset.md
@@ -5,13 +5,12 @@ form:
     fields:
         - name: username
           type: text
-          placeholder: Username
+          placeholder: PLUGIN_ADMIN.USERNAME
           readonly: true
         - name: password
           type: password
-          placeholder: Password
+          placeholder: PLUGIN_ADMIN.PASSWORD
           autofocus: true
         - name: token
           type: hidden
 ---
-


### PR DESCRIPTION
I modified the forms : login, logout, reset and forgot to use the translated strings in the placeholder of the fields.