### PR TITLE
Remove white-space: nowrap

### DIFF
--- a/themes/grav/scss/template/_buttons.scss
+++ b/themes/grav/scss/template/_buttons.scss
@@ -82,7 +82,6 @@
             clear: both;
             font-weight: 400;
             line-height: 1.42857143;
-            white-space: nowrap;
 
             &:focus, &:hover {
                 text-decoration: none;


### PR DESCRIPTION
The selector ".button-group .dropdown-menu li>a" has a "white-space: nowrap" property that prevent button list items for being displayed in more that one line. There is a problem on translated items which are longer than english ones, such as "Add modular" in english that becomes "Ajouter un contenu modulaire" in french.

Button list items needs to be displayed in multiple lines if their text is too long.

For more details, see screenshots below : 
https://cloud.githubusercontent.com/assets/6952638/14977647/fe24e52a-1115-11e6-87dc-59e3a2a0ea1c.png
https://cloud.githubusercontent.com/assets/6952638/14977654/0d906c82-1116-11e6-8621-0e283438827e.png