### PR TITLE
Provide security options for single tabs

### DIFF
--- a/themes/grav/templates/forms/fields/tabs/tabs.html.twig
+++ b/themes/grav/templates/forms/fields/tabs/tabs.html.twig
@@ -22,10 +22,12 @@
     <div class="tab-body-wrapper">
         {% for field in field.fields %}
             {% if field.type == 'tab' %}
-                {% set value = data.value(field.name) %}
-                <div id="tab-body-{{ tabsKey ~ loop.index }}" class="tab-body">
-                    {% include ["forms/fields/#{field.type}/#{field.type}.html.twig", 'forms/fields/text/text.html.twig'] %}
-                </div>
+                {% if field.security is empty or authorize(array(field.security)) %}
+                    {% set value = data.value(field.name) %}
+                    <div id="tab-body-{{ tabsKey ~ loop.index }}" class="tab-body">
+                        {% include ["forms/fields/#{field.type}/#{field.type}.html.twig", 'forms/fields/text/text.html.twig'] %}
+                    </div>
+                {% endif %}
             {% endif %}
         {% endfor %}
     </div>


### PR DESCRIPTION
This PR allows to attach security options to single tabs (`tab`). Just like `section`.