### PR TITLE
Responsive button display error

### DIFF
--- a/themes/grav/scss/template/_admin.scss
+++ b/themes/grav/scss/template/_admin.scss
@@ -537,7 +537,7 @@ body.sidebar-quickopen #admin-main {
             vertical-align: top;
 
             @include breakpoint(mobile-only) {
-                font-size: 0;
+                font-size: 0.9em;
                 padding: 0.5rem 0.5rem;
                 min-height: 36px;
                 i {


### PR DESCRIPTION
This fixes the add folder/modular missing text issue #647 for the add folder/add module text not displaying when viewing display ports 60 or under.
button font-size class was set to 0 for mobile.