### PR TITLE
Add field description to forms

### DIFF
--- a/themes/grav/scss/template/_forms.scss
+++ b/themes/grav/scss/template/_forms.scss
@@ -21,6 +21,11 @@ form {
         padding: 1.5rem 3rem;
     }
 
+    .form-description {
+        font-weight: bold;
+        font-size: small;
+    }
+
     .form-field {
         margin-bottom: 1rem;
         padding-left: $padding-default;

--- a/themes/grav/templates/forms/field.html.twig
+++ b/themes/grav/templates/forms/field.html.twig
@@ -70,6 +70,11 @@
                         </div>
                     {% endblock %}
                 {% endblock %}
+                {% if field.description %}
+                    <div class="form-extra-wrapper {{ field.size }} {{ field.wrapper_classes }}">
+                        <span class="form-description">{{ field.description }}</span>
+                    </div>
+                {% endif %}
             </div>
         {% endblock %}
     </div>

--- a/themes/grav/templates/forms/field.html.twig
+++ b/themes/grav/templates/forms/field.html.twig
@@ -72,7 +72,7 @@
                 {% endblock %}
                 {% if field.description %}
                     <div class="form-extra-wrapper {{ field.size }} {{ field.wrapper_classes }}">
-                        <span class="form-description">{{ field.description }}</span>
+                        <span class="form-description">{{ field.description|raw }}</span>
                     </div>
                 {% endif %}
             </div>


### PR DESCRIPTION
This PR allows description for form fields:

![description](https://cloud.githubusercontent.com/assets/9073307/16130784/02a9ae10-340b-11e6-9075-db45fd6ceb25.png)

In order to show the styling, the SCSS have to be recompiled again.

 