### PR TITLE
closed 704, fixed favicon url

### DIFF
--- a/themes/grav/templates/partials/base.html.twig
+++ b/themes/grav/templates/partials/base.html.twig
@@ -15,8 +15,7 @@
         <meta name="robots" content="noindex, nofollow">
     {% endif %}
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/png" href="{{ base_url_simple }}/{{ theme_url }}/images/favicon.png">
-
+    <link rel="icon" type="image/png" href="{{ theme_url }}/images/favicon.png">
     {% block stylesheets %}
         {% include 'partials/stylesheets.html.twig' %}
         {{ assets.css()|raw }}


### PR DESCRIPTION
Removed base_url_simple out of the favicon url, base_url_simple doesn't seem to contain anything.

Fixes #704 