### PR TITLE
Default headers

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -321,4 +321,23 @@ form:
       label: Visitors history
       default: 20
 
+    Editor:
+      type: section
+      title: Editor
+      underline: true
 
+    editor.default_headers:
+      classes: frontmatter
+      type: editor
+      label: Default Headers
+      size: large
+      codemirror:
+        mode: 'yaml'
+        indentUnit: 4
+        autofocus: true
+        indentWithTabs: false
+        lineNumbers: true
+        styleActiveLine: true
+        gutters: ['CodeMirror-lint-markers']
+        lint: true
+      help: Default headers to add to new pages

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -329,7 +329,7 @@ form:
     editor.default_headers:
       classes: frontmatter
       type: editor
-      label: Default Headers
+      label: Default Page Headers
       size: large
       codemirror:
         mode: 'yaml'
@@ -340,4 +340,4 @@ form:
         styleActiveLine: true
         gutters: ['CodeMirror-lint-markers']
         lint: true
-      help: Default headers to add to new pages
+      help: Default page headers to automatically add to any new page created

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -321,12 +321,12 @@ form:
       label: Visitors history
       default: 20
 
-    Editor:
+    Frontmatter:
       type: section
-      title: Editor
+      title: Frontmatter
       underline: true
 
-    editor.default_headers:
+    frontmatter.default_headers:
       classes: frontmatter
       type: editor
       label: Default Page Headers

--- a/classes/admin.php
+++ b/classes/admin.php
@@ -745,7 +745,11 @@ class Admin
                 // Found the type and header from the session.
                 $data = $this->session->{$page->route()};
 
-                $header = ['title' => $data['title']];
+                // Initialise the page headers with the default page headers
+                $default_headers = $this->grav['config']->get('plugins.admin.editor.default_headers');
+                $header = Yaml::parse($default_headers);
+
+                $header['title'] = $data['title'];
 
                 if (isset($data['visible'])) {
                     if ($data['visible'] == '' || $data['visible']) {

--- a/classes/admin.php
+++ b/classes/admin.php
@@ -749,7 +749,7 @@ class Admin
 
                 // Merge the default page headers into $header
                 $default_headers = Yaml::parse(
-                  $this->grav['config']->get('plugins.admin.editor.default_headers'));
+                  $this->grav['config']->get('plugins.admin.frontmatter.default_headers'));
 
                 $header = (object) array_merge((array) $header, (array) $default_headers);
 

--- a/classes/admin.php
+++ b/classes/admin.php
@@ -745,11 +745,13 @@ class Admin
                 // Found the type and header from the session.
                 $data = $this->session->{$page->route()};
 
-                // Initialise the page headers with the default page headers
-                $default_headers = $this->grav['config']->get('plugins.admin.editor.default_headers');
-                $header = Yaml::parse($default_headers);
+                $header = ['title' => $data['title']];
 
-                $header['title'] = $data['title'];
+                // Merge the default page headers into $header
+                $default_headers = Yaml::parse(
+                  $this->grav['config']->get('plugins.admin.editor.default_headers'));
+
+                $header = (object) array_merge((array) $header, (array) $default_headers);
 
                 if (isset($data['visible'])) {
                     if ($data['visible'] == '' || $data['visible']) {
@@ -770,7 +772,12 @@ class Admin
                 }
 
                 if ($data['name'] == 'modular') {
-                    $header['body_classes'] = 'modular';
+                  // Make sure body_classes exists, so we can concat 'modular' to it
+                  if(!array_key_exists('body_classes', $header)) {
+                    $header['body_classes'] = '';
+                  }
+
+                  $header['body_classes'] .= ' modular';
                 }
 
                 $name = $page->modular() ? str_replace('modular/', '', $data['name']) : $data['name'];

--- a/themes/grav/templates/forms/fields/editor/editor.html.twig
+++ b/themes/grav/templates/forms/fields/editor/editor.html.twig
@@ -7,7 +7,7 @@
     {% if field.label %}
         <div
           class="form-label form-field hint--bottom"
-          {% if field.help %}data-hint="{{field.help|tu|raw}}" {% endif %}
+          {% if field.help %}data-hint="{{field.help|tu|e('html_attr')}}" {% endif %}
         >{{ field.label|tu|raw }}</div>
     {% endif %}
 {% endblock %}

--- a/themes/grav/templates/forms/fields/editor/editor.html.twig
+++ b/themes/grav/templates/forms/fields/editor/editor.html.twig
@@ -5,8 +5,10 @@
 
 {% block label %}
     {% if field.label %}
-        {% set hint = field.help ? 'data-hint="' ~ field.help|tu|raw ~ '"': '' %}
-        <div class="form-label form-field hint--bottom" {{ hint }}>{{ field.label|tu|raw }}</div>
+        <div
+          class="form-label form-field hint--bottom"
+          {% if field.help %}data-hint="{{field.help|tu|raw}}" {% endif %}
+        >{{ field.label|tu|raw }}</div>
     {% endif %}
 {% endblock %}
 {% block field %}


### PR DESCRIPTION
This PR does the following:

 * Adds an "Frontmatter" section to the grav-admin plugin options
 * Adds an editor option to set some initial headers into a new page
 * Fixes a minor bug that stopped the "help" text from being readable

This will allow headers to be specified in plugin options for the admin plugin, and (unless overridden) will be present on all new page creations (through the admin plugin)

The specific use-case in mind is to add automatically the
```
access:
  site.login: true
  admin.login: true
```
headers required by the login plugin for pages to be log-in only