### PR TITLE
fix problem when $parent is null

### DIFF
--- a/classes/controller.php
+++ b/classes/controller.php
@@ -1897,7 +1897,9 @@ class AdminController
             $original_order = intval(trim($obj->order(), '.'));
 
             // Change parent if needed and initialize move (might be needed also on ordering/folder change).
-            $obj = $obj->move($parent);
+            if ($parent != null) {
+                $obj = $obj->move($parent);
+            }
             $this->preparePage($obj, false, $obj->language());
 
             // Reset slug and route. For now we do not support slug twig variable on save.


### PR DESCRIPTION
When creating a page on root, there is no $parent object. The move function expect an non null object.
