### PR TITLE
feat(taxonomy): allow taxonomy fields to be styled vertical

### DIFF
--- a/themes/grav/templates/forms/fields/taxonomy/taxonomy.html.twig
+++ b/themes/grav/templates/forms/fields/taxonomy/taxonomy.html.twig
@@ -14,6 +14,7 @@
         name: parentname ~ '.' ~ name,
         multiple: true,
         options: list,
+        style: field.style,
         selectize: {
             create: true
         }


### PR DESCRIPTION
This implements support for the vertical style to be used with taxonomy fields.

```yaml
header.taxonomy:
  type: taxonomy
  label: PLUGIN_ADMIN.TAXONOMY
  multiple: true
  style: vertical
  validate:
    type: array
```