### PR TITLE
Fix Ctrl+S does not save changes to a page

### DIFF
--- a/themes/grav/app/forms/form.js
+++ b/themes/grav/app/forms/form.js
@@ -31,10 +31,7 @@ export default class Form {
 
     _attachShortcuts() {
         // CTRL + S / CMD + S - shortcut for [Save] when available
-        let saveTask = $('[name="task"][value="save"]').filter(function(index, element) {
-            element = $(element);
-            return !(element.parents('.remodal-overlay').length);
-        });
+        let saveTask = $('#titlebar [name="task"][value="save"]');
 
         if (saveTask.length) {
             $(global).on('keydown', function(event) {


### PR DESCRIPTION
Press Ctrl+S when editing a page does trigger a save prompt, however,
the content is not saved.

This was broken because Remodal changed their DOM structure in commit
[461d5ec307a3214e0d2c1427b613178236ed9293](https://github.com/VodkaBears/Remodal/commit/461d5ec307a3214e0d2c1427b613178236ed9293), which caused the
"remodal-overlay" not to be a parent of the "Continue" button.

This commit updated the selector to rely on the DOM structure we
control, so that hopefully it will not break again if Remodal changes.