### PR TITLE
Use chevron icons for Expand/Collapse All

### DIFF
--- a/themes/grav/templates/pages.html.twig
+++ b/themes/grav/templates/pages.html.twig
@@ -265,8 +265,8 @@
                 <input type="text" placeholder="{{ "PLUGIN_ADMIN.SEARCH_PAGES"|tu }}" name="page-search" />
             </div>
             <div class="page-shortcuts">
-                <span class="button button-x-small" data-page-toggleall="expand"><i class="fa fa-fw fa-plus-circle"></i> {{ "PLUGIN_ADMIN.EXPAND_ALL"|tu }}</span>
-                <span class="button button-x-small" data-page-toggleall="collapse"><i class="fa fa-fw fa-minus-circle"></i> {{ "PLUGIN_ADMIN.COLLAPSE_ALL"|tu }}</span>
+                <span class="button button-x-small" data-page-toggleall="expand"><i class="fa fa-fw fa-chevron-circle-down"></i> {{ "PLUGIN_ADMIN.EXPAND_ALL"|tu }}</span>
+                <span class="button button-x-small" data-page-toggleall="collapse"><i class="fa fa-fw fa-chevron-circle-right"></i> {{ "PLUGIN_ADMIN.COLLAPSE_ALL"|tu }}</span>
             </div>
         </form>
         <div class="pages-list">


### PR DESCRIPTION
To be consistent with the Media page using the chevron icons.