### PR TITLE
spaceless tag

### DIFF
--- a/themes/grav/templates/partials/base.html.twig
+++ b/themes/grav/templates/partials/base.html.twig
@@ -1,4 +1,5 @@
 {% if uri.extension() == 'json' %}{% include 'default.json.twig' %}{% else %}
+    {% spaceless %}
     <!DOCTYPE html>
     <html lang="en">
     <head>
@@ -98,4 +99,5 @@
     </body>
     {% endblock body %}
     </html>
+    {% endspaceless %}
 {% endif %}


### PR DESCRIPTION
Spaceless tag to remove whitespace between HTML tags. Slightly reduce the output code and faster loading