### PR TITLE
Add range-field

### DIFF
--- a/themes/grav/templates/forms/fields/range/range.html.twig
+++ b/themes/grav/templates/forms/fields/range/range.html.twig
@@ -1,0 +1,19 @@
+{% extends "forms/field.html.twig" %}
+
+{% block input_attributes %}
+    type="range"
+	style="display: inline-block;vertical-align: middle;"
+	{% if field.id is defined %}
+		oninput="{{ field.id|e }}_output.value = {{ field.id|e }}.value"
+	{% endif %}
+    {% if field.validate.min %}min="{{ field.validate.min }}"{% endif %}
+    {% if field.validate.max %}max="{{ field.validate.max }}"{% endif %}
+    {{ parent() }}
+{% endblock %}
+{% block append %}
+	{% if field.id is defined %}
+		<output name="{{ (scope ~ field.name)|fieldName }}" id="{{ field.id|e }}_output" style="display: inline-block;vertical-align: baseline;padding: 0 0.5em 5px 0.5em;">
+			{{ value|join(', ')|e('html_attr') }}
+		</output>
+	{% endif %}
+{% endblock append %}


### PR DESCRIPTION
Uses input with type 'range' to create a HTML5 slider-element. Current implementation is with inline styles, due to the lack of (apparent) implementations with PureCSS. See [W3C Wiki](https://www.w3.org/wiki/HTML/Elements/input/range) for specification, [Zurb's Foundation](http://foundation.zurb.com/sites/docs/v/5.5.3/components/range_slider.html) for common implementation, [Can I Use](http://caniuse.com/#feat=input-range) for browser-support.

It can be used in a pure state without much style or any script, but the inline `oninput`-script is added for the value callbacks as the slider is fairly limited in use without knowing the number selected. Could be better-looking adding in parts of a CSS framework. A touch-friendly, responsive [polyfill](http://rangeslider.js.org/) with extended browser-support - especially handy for min, max, and step values - is available.

Use case example:

![image](https://cloud.githubusercontent.com/assets/974717/23235976/cf1be51e-f957-11e6-8ae1-5106f887ded2.png)

And [simple implementation](https://github.com/OleVik/grav-plugin-adminidenticons/blob/master/blueprints.yaml#L36-L42) in a blueprint.