### PR TITLE
don't disable page ordering when the collection is @self.children and the order is default

### DIFF
--- a/themes/grav/templates/forms/fields/order/order.html.twig
+++ b/themes/grav/templates/forms/fields/order/order.html.twig
@@ -14,23 +14,27 @@
     </div>
     <div class="form-data block size-2-3 pure-u-2-3">
         <div class="form-order-wrapper {{ field.size }}">
-            {% set canReorder = not data.parent.header.content.items and data.visible %}
+            {% set orderingDisabledReason = null %}
+            {% if not data.visible %}
+                {% set orderingDisabledReason = "PLUGIN_ADMIN.ORDERING_DISABLED_BECAUSE_PAGE_NOT_VISIBLE"|tu %}
+            {% elseif data.parent.header.content.items and (data.parent.header.content.items != '@self.children' or (data.parent.header.content.order.by and data.parent.header.content.order.by != 'default')) %}
+                {% set orderingDisabledReason = "PLUGIN_ADMIN.ORDERING_DISABLED_BECAUSE_PARENT_SETTING_ORDER"|tu %}
+            {% endif %}
+            {% set orderingEnabled = (orderingDisabledReason == null) %}
             <input
                 type="hidden"
                 data-order
                 {% if field.disabled or isDisabledToggleable %}disabled="disabled"{% endif %}
                 name="{{ (scope ~ field.name)|fieldName }}"
-                value="{{ canReorder ? value : '' }}" />
-            {% if data.parent.header.content.items %}
-                <span class="note">{{ "PLUGIN_ADMIN.ORDERING_DISABLED_BECAUSE_PARENT_SETTING_ORDER"|tu }}</span>
-            {% elseif not data.visible %}
-                <span class="note">{{ "PLUGIN_ADMIN.ORDERING_DISABLED_BECAUSE_PAGE_NOT_VISIBLE"|tu }}</span>
+                value="{{ orderingEnabled ? value : '' }}" />
+            {% if orderingDisabledReason %}
+                <span class="note">{{ orderingDisabledReason }}</span>
             {% endif %}
 
             {% if siblings|length < 200 %}
 				<ul id="ordering" class="{{ field.classes }}">
 			    {% for page in siblings %}
-					<li class="{% if page.order  == value and canReorder %}drag-handle{% else %}ignore{% endif %}" data-id="{{ page.slug }}">{{ page.title|e }}</li>
+					<li class="{% if page.order  == value and orderingEnabled %}drag-handle{% else %}ignore{% endif %}" data-id="{{ page.slug }}">{{ page.title|e }}</li>
                 {% endfor %}
 				</ul>
 			{% else %}


### PR DESCRIPTION
This fixes the undesirable behaviour of disabling the ordering of a page's children when it defines a collection of items with `header.content.items: @self.children` and `header.content.order.by: default`. In that case, the collection on the front-end is effectively in the order set by the user in the admin panel (which is also the folders prefix order), so it makes sense to enable it and there shouldn't be any confusion like there is when the collection is not the page's children, as explained to me by @rhukster on Slack.

Issue #786 was about this. It was closed because a workaround was suggested, but I think this fix is better as it allows you to use some of the great features of collections such as `url_taxonomy_filters` to filter through the page's children to display, in addition to letting the admin set their order.