### PR TITLE
Make userinfo-avatar modular again

### DIFF
--- a/themes/grav/templates/forms/fields/userinfo/userinfo.html.twig
+++ b/themes/grav/templates/forms/fields/userinfo/userinfo.html.twig
@@ -1,10 +1,6 @@
 <div class="form-field grid user-details">
     <div class="form-label block size-1-3">
-        {% if data.avatar %}
-            <label><img src="{{ base_url_simple ~ '/' ~ (data.avatar|first).path }}" /></label>
-        {% else %}
-            <label>{% include 'partials/userinfo-avatar.html.twig' %}</label>
-        {% endif %}
+        {% include 'partials/userinfo-avatar.html.twig' %}
     </div>
     <div class="form-data block size-2-3">
         <h2>{{ data.fullname }}</h2>

--- a/themes/grav/templates/partials/userinfo-avatar.html.twig
+++ b/themes/grav/templates/partials/userinfo-avatar.html.twig
@@ -1,1 +1,5 @@
-<img src="https://www.gravatar.com/avatar/{{ data.email|md5 }}?s=200" />
+{% if data.avatar %}
+    <label><img src="{{ base_url_simple ~ '/' ~ (data.avatar|first).path }}" /></label>
+{% else %}
+    <label><img src="https://www.gravatar.com/avatar/{{ data.email|md5 }}?s=200" /></label>
+{% endif %}


### PR DESCRIPTION
Allow template partials to override userinfo-avatar.html.twig non-destructively, consistent with [989](https://github.com/getgrav/grav-plugin-admin/pull/989).