### PR TITLE
Update admincontroller.php

### DIFF
--- a/classes/admincontroller.php
+++ b/classes/admincontroller.php
@@ -1783,7 +1783,7 @@ class AdminController extends AdminBaseController
 
 
 
-        if ($input['folder'] != $page->value('folder')) {
+        if (isset($input['folder']) && $input['folder'] != $page->value('folder')) {
             $order    = $page->value('order');
             $ordering = $order ? sprintf('%02d.', $order) : '';
             $page->folder($ordering . $input['folder']);


### PR DESCRIPTION
check if variable "folder" is set in $input

The problem occurred in the admin, when we tried to save a modular page (in "normal mode"; in expert mode everything was fine).

Adding "isset($input['folder']) && " in line 1786 fixed it.

![image](https://cloud.githubusercontent.com/assets/25477867/24808485/29b5f844-1bbc-11e7-849c-6b3f84b71932.png)
