### PR TITLE
Fix fullscreen editor height #722

### DIFF
--- a/themes/grav/scss/template/_editor.scss
+++ b/themes/grav/scss/template/_editor.scss
@@ -32,13 +32,29 @@
     z-index: 99999;
     padding: 0 !important;
     margin: 0 !important;
+    display: flex;
+    flex-direction: column;
+
+    .grav-editor-content {
+        display: flex;
+        flex-direction: column;
+        flex: 1 0 0;
+    }
 
     .grav-editor-content, .CodeMirror-wrap, .grav-editor-preview {
         height: 100% !important;
     }
 
+    .grav-editor-toolbar {
+        flex: 0 0 auto;
+    }
+
     .grav-editor-toolbar, .grav-editor-toolbar ul li:first-child a, .grav-editor-toolbar-flip ul li:last-child a {
         border-radius: 0 !important;
+    }
+
+    .grav-editor-resizer {
+        display: none;
     }
 }
 


### PR DESCRIPTION
Hi there!

This should fix the issue with the fullscreen editor.

https://github.com/getgrav/grav-plugin-admin/issues/722

P.S. Whenever I tried to compile SCSS it generated to totally different source map files. I don't want to clutter the pull request with those.