### PR TITLE
More robust themes style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.3.X
+## XX/XX/2017
+
+1. [](#improved)
+    * More robust styling of admin themes page [#1067](https://github.com/getgrav/grav-plugin-admin/pull/1067)
+
 # v1.3.3
 ## 04/12/2017
 

--- a/themes/grav/scss/template/_gpm.scss
+++ b/themes/grav/scss/template/_gpm.scss
@@ -159,6 +159,9 @@
     .themes {
         padding: $padding-default;
 
+        .card-item {
+            padding: 1rem 1rem 4rem;
+        }
 
         .gpm-screenshot {
             text-align: center;
@@ -170,6 +173,7 @@
 
         .gpm-name {
             margin-bottom: 0.5rem;
+            white-space: inherit;
         }
 
         .gpm-actions {
@@ -179,6 +183,11 @@
             padding: 1rem;
             font-size: 1rem;
             font-weight: bold;
+
+            position: absolute;
+            left: 0;
+            right: 0;
+            bottom: 1rem;
         }
 
         .active-theme .gpm-actions, &.inactive-theme .gpm-actions {


### PR DESCRIPTION
This PR address a CSS styling issue, see issue before my changes:

![before](https://cloud.githubusercontent.com/assets/9073307/25038397/f238cf16-20fe-11e7-9f98-a4050761d4c1.png)

And after my changes:

![after](https://cloud.githubusercontent.com/assets/9073307/25038405/f83bca4e-20fe-11e7-8661-352e9815f90a.png)

I made changes to the SCSS files. Thus, a recompilation is necessary.