### PR TITLE
Initialize theme in Admin Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## 04/xx/2017
 
 1. [](#improved)
+    * Initialize theme in Admin Plugin [#1069](https://github.com/getgrav/grav-plugin-admin/pull/1069)
     * Use new system configuration entries for username and password format
     * Reworked Page parent field to use `Pages::getList()` rather than logic in Twig field itself
     * More robust styling of admin themes page [#1067](https://github.com/getgrav/grav-plugin-admin/pull/1067)

--- a/classes/themes.php
+++ b/classes/themes.php
@@ -14,6 +14,7 @@ class Themes extends \Grav\Common\Themes
         /** @var Themes $themes */
         $themes = $this->grav['themes'];
         $themes->configure();
+        $themes->initTheme();
 
         $this->grav->fireEvent('onAdminThemeInitialized');
     }


### PR DESCRIPTION
Currently, the default site theme is not initialized in Admin Plugin. This PR changes this and allows to use custom theme hooks to manipulate the Admin Plugin directly (like plugins do already). 