### PR TITLE
Admin fields improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # v1.4.3
 ## 04/xx/2017
 
+1. [](#improved)
+    * Admin form fields improvements for `selectize` and `editor` field [#1083](https://github.com/getgrav/grav-plugin-admin/pull/1083)
 1. [](#bugfix)
     * Added `vendor` to ignores for direct install of Grav
     * Translated `field.default` for `editor` form field

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 1. [](#new)
     * Added a new `Content Padding` option to tighten up UI padding space (default `true`)
+1. [](#improved)
+    * Admin form fields improvements for `selectize` and `editor` field [#1083](https://github.com/getgrav/grav-plugin-admin/pull/1083)
 1. [](#bugfix)
     * Added back `Admin::initTheme()` relying on Grav fix [#1069](https://github.com/getgrav/grav-plugin-admin/pull/1069) as it conflicts ith Gantry5
     * Fix for missing scrollbar when in full-size editor for Firefox [#1077](https://github.com/getgrav/grav-plugin-admin/issues/1077)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@
 
 1. [](#new)
     * Added a new `Content Padding` option to tighten up UI padding space (default `true`)
-1. [](#improved)
-    * Admin form fields improvements for `selectize` and `editor` field [#1083](https://github.com/getgrav/grav-plugin-admin/pull/1083)
 1. [](#bugfix)
     * Added back `Admin::initTheme()` relying on Grav fix [#1069](https://github.com/getgrav/grav-plugin-admin/pull/1069) as it conflicts ith Gantry5
     * Fix for missing scrollbar when in full-size editor for Firefox [#1077](https://github.com/getgrav/grav-plugin-admin/issues/1077)

--- a/themes/grav/templates/forms/field.html.twig
+++ b/themes/grav/templates/forms/field.html.twig
@@ -9,7 +9,7 @@
 {% endif %}
 
 {% block field %}
-    <div class="form-field grid{% if vertical %} vertical{% endif %}{% if field.toggleable %} form-field-toggleable{% endif %} {{ field.field_classes }}">
+    <div class="form-field grid{% if vertical %} vertical{% endif %}{% if field.toggleable %} form-field-toggleable{% endif %} {{ field.field_classes|default(field.classes)|default('') }}">
         {% block contents %}
             <div class="form-label{% if not vertical %} block size-1-3{% endif %}">
                 {% if field.toggleable %}

--- a/themes/grav/templates/forms/fields/editor/editor.html.twig
+++ b/themes/grav/templates/forms/fields/editor/editor.html.twig
@@ -1,35 +1,45 @@
+{% extends "forms/field.html.twig" %}
+
+{# Fallback #}
+{% if field.style is not defined %}
+    {% set field = field|merge({'style': 'vertical'}) %}
+{% endif %}
+
 {% set value = (value is null ? field.default|tu : value) %}
 {% if not codemirrorOptions %}
     {% set codemirrorOptions = {'mode': 'gfm', 'ignore': ['code', 'preview']}|merge(field.codemirror|default({})) %}
 {% endif %}
 
-{% block label %}
-    {% if field.label %}
-        {% set hint = field.help ? 'data-hint="' ~ field.help|tu|raw ~ '"': '' %}
-        <div class="form-label form-field hint--bottom" {{ hint }}>{{ field.label|tu|raw }}</div>
-    {% endif %}
-{% endblock %}
-{% block field %}
-    <div class="form-field {{ field.classes|default('') }}">
-        <div class="form-data grav-editor">
-            <div class="grav-editor-content">
-                <textarea
-                    data-grav-editor="{{ {'codemirror': codemirrorOptions} | json_encode|e('html_attr') }}"
-                    data-grav-editor-mode="editor"
-                    name="{{ (scope ~ field.name)|fieldName }}"
-                    {% if field.classes is defined %}class="{{ field.classes }}" {% endif %}
-                    {% if field.id is defined %}id="{{ field.id|e }}" {% endif %}
-                    {% if field.style is defined %}style="{{ field.style|e }}" {% endif %}
-                    {% if field.disabled or isDisabledToggleable %}disabled="disabled"{% endif %}
-                    {% if field.placeholder %}placeholder="{{ field.placeholder|tu }}"{% endif %}
-                    {% if field.autofocus in ['on', 'true', 1] %}autofocus="autofocus"{% endif %}
-                    {% if field.novalidate in ['on', 'true', 1] %}novalidate="novalidate"{% endif %}
-                    {% if field.readonly in ['on', 'true', 1] %}readonly="readonly"{% endif %}
-                    {% if field.validate.required in ['on', 'true', 1] %}required="required"{% endif %}
-                    {% if 'preview' not in codemirrorOptions.ignore %}data-grav-urlpreview="{{ base_url }}/media/{{ admin.route|trim('/') }}.json"{% endif %}
-                >{{ value|join("\n")|e('html') }}</textarea>
-            </div>
-            {% if field.resizer is not defined or field.resizer not in ['off', 'false', 0] %}<div class="grav-editor-resizer"></div>{% endif %}
+{% block group %}
+    <div class="grav-editor">
+        {# Inject targeted CSS to set the height of the CodeMirror editor #}
+        {% if field.lines %}
+            <style type="text/css">
+                textarea[name="{{ (scope ~ field.name)|fieldName }}"] + .CodeMirror {
+                    height: {{ 1 + 1.4 * field.lines }}em;
+                    line-height: 1.4;
+                }
+            </style>
+        {% endif %}
+        
+        {# Embed Grav Editor #}
+        <div class="grav-editor-content">
+            <textarea
+                data-grav-editor="{{ {'codemirror': codemirrorOptions} | json_encode|e('html_attr') }}"
+                data-grav-editor-mode="editor"
+                name="{{ (scope ~ field.name)|fieldName }}"
+                {% if field.classes is defined %}class="{{ field.classes }}" {% endif %}
+                {% if field.id is defined %}id="{{ field.id|e }}" {% endif %}
+                {% if field.style is defined %}style="{{ field.style|e }}" {% endif %}
+                {% if field.disabled or isDisabledToggleable %}disabled="disabled"{% endif %}
+                {% if field.placeholder %}placeholder="{{ field.placeholder|tu }}"{% endif %}
+                {% if field.autofocus in ['on', 'true', 1] %}autofocus="autofocus"{% endif %}
+                {% if field.novalidate in ['on', 'true', 1] %}novalidate="novalidate"{% endif %}
+                {% if field.readonly in ['on', 'true', 1] %}readonly="readonly"{% endif %}
+                {% if field.validate.required in ['on', 'true', 1] %}required="required"{% endif %}
+                {% if 'preview' not in codemirrorOptions.ignore %}data-grav-urlpreview="{{ base_url }}/media/{{ admin.route|trim('/') }}.json"{% endif %}
+            >{{ value|join("\n")|e('html') }}</textarea>
         </div>
+        {% if field.resizer is not defined or field.resizer not in ['off', 'false', 0] %}<div class="grav-editor-resizer"></div>{% endif %}
     </div>
 {% endblock %}

--- a/themes/grav/templates/forms/fields/selectize/selectize.html.twig
+++ b/themes/grav/templates/forms/fields/selectize/selectize.html.twig
@@ -1,7 +1,29 @@
 {% extends "forms/field.html.twig" %}
 
 {% block global_attributes %}
-    data-grav-selectize="{{ (field.selectize is defined ? field.selectize|merge({'create': true}) : {'create': true})|json_encode()|e('html_attr') }}"
+    {% set selectize = (field.selectize is defined ? field.selectize|merge({'create': true}) : {'create': true}) %}
+    {% set value = (value is iterable ? value: value|split(',')) %}
+    
+    {% set values = {} %}
+    {% if value is iterable %}
+        {% for v in value %}
+            {% set values = values|merge({(v): v}) %}
+        {% endfor %}
+    {% elseif value is not empty %}
+        {% set values = values|merge([{(value): value}]) %}
+    {% endif %}
+    
+    {% set options = [] %}
+    {% set field_options = (field.options is defined ? field.options : {}) %}
+    {% for key, text in values|merge(field_options) %}
+        {% set label = (field.use == 'keys' ? key : text) %}
+        {% set translated = (grav.twig.twig.filters['tu'] is defined ? text|tu|raw : text|t|raw) %}
+        {% set options = options|merge([{'text': text, 'value': label}]) %}
+    {% endfor %}
+    
+    {% set selectize = selectize|merge({'options': options, 'items': values|keys}) %}
+    data-grav-selectize="{{ selectize|json_encode()|e('html_attr') }}"
+    data-grav-keys="{{ field.use == 'keys' ? 'true' : 'false' }}"
     {{ parent() }}
 {% endblock %}
 


### PR DESCRIPTION
This PR adds support for custom options in `selectize` field similar to the way how `checkboxes` works via, e.g,

```yaml
myfield:
  type: selectize
  label: My Label
  options:
    key1: Just
    key2: some
    key3: words
  use: keys
```

See screenshot:

![editor selectize](https://cloud.githubusercontent.com/assets/9073307/25306583/6627a180-2790-11e7-9744-ac41ac848f7b.png)

and refactors the `editor` field that now extends `field.html.twig` (and allows descriptions and a `style: vertical` as well as `style: horizontal` alignment):

```yaml
myeditor:
  type: editor
  label: Editor
  description: Description
  style: horizontal   # 'vertical' or 'horizontal'
  lines: 5   # How many lines to show

  codemirror:
    ...
```

If the style option is not set, it defaults to `vertical` as this is the current default option. It further allows to set how many lines should be shown by default (see above and below screenshot).

![editor](https://cloud.githubusercontent.com/assets/9073307/25306584/696721b8-2790-11e7-8205-b33f84b6ce1c.png)

Last but not least, this PR allows to add additional CSS classes via the field `classes` option (not only `field_classes`).
