### PR TITLE
Fix error in en.yaml

### DIFF
--- a/languages/en.yaml
+++ b/languages/en.yaml
@@ -416,7 +416,7 @@ PLUGIN_ADMIN:
   IS_NOW_AVAILABLE: "is now available"
   CURRENT: "Current"
   UPDATE_GRAV_NOW: "Update Grav Now"
-  GRAV_SYMBOLICALLY_LINKED: "Grav is symbolically linked. Upgrade won\'t be available"
+  GRAV_SYMBOLICALLY_LINKED: "Grav is symbolically linked. Upgrade won't be available"
   UPDATING_PLEASE_WAIT: "Updating... please wait, downloading"
   OF_THIS: "of this"
   OF_YOUR: "of your"


### PR DESCRIPTION
The single-quote does not need escaping when string is enclosed in double-quotes, and throws the parser.