### PR TITLE
Fix `selectize.html.twig` for empty value

### DIFF
--- a/themes/grav/templates/forms/fields/selectize/selectize.html.twig
+++ b/themes/grav/templates/forms/fields/selectize/selectize.html.twig
@@ -6,7 +6,7 @@
     
     {% set values = {} %}
     {% if value is iterable %}
-        {% for v in value %}
+        {% for v in value if v %}
             {% set values = values|merge({(v): v}) %}
         {% endfor %}
     {% elseif value is not empty %}


### PR DESCRIPTION
It seems like I haven't covered all edge cases in the `selectize` field widget #1083 . For empty values it currently shows an empty box. Checking for a value (see changes) fixes this.