### PR TITLE
Fix fullscreen editor

### DIFF
--- a/themes/grav/app/forms/fields/editor/buttons.js
+++ b/themes/grav/app/forms/fields/editor/buttons.js
@@ -307,10 +307,10 @@ export default {
                     let previewContainer = textarea.data('grav-editor-preview-container');
                     let content = textarea.parent('.grav-editor-content');
 
-                    content.css('display', 'block');
+                    content.addClass('is-active');
                     ui.navigation.find('.grav-editor-actions').css('visibility', 'visible');
                     if (previewContainer) {
-                        previewContainer.css('display', 'none');
+                        previewContainer.removeClass('is-active');
                     }
                 });
             }
@@ -338,8 +338,9 @@ export default {
                         textarea.data('grav-editor-preview-container', previewContainer);
                     }
 
-                    previewContainer.css({ height: content.height(), display: 'block' });
-                    content.css('display', 'none');
+                    previewContainer.css({ height: content.height() });
+                    previewContainer.addClass('is-active');
+                    content.removeClass('is-active');
                     ui.navigation.find('.grav-editor-actions').css('visibility', 'hidden');
 
                     let url = `${textarea.data('grav-urlpreview')}/task${config.param_sep}processmarkdown`;

--- a/themes/grav/scss/template/_editor.scss
+++ b/themes/grav/scss/template/_editor.scss
@@ -61,6 +61,10 @@
     .grav-editor-resizer {
         display: none;
     }
+
+    .grav-editor-content.is-active {
+        display: flex;
+    }
 }
 
 .grav-editor-toolbar {
@@ -146,6 +150,11 @@
 .grav-editor-content, .grav-editor-preview {
     @include clearfix;
     cursor: text;
+    display: none;
+
+    &.is-active {
+        display: block;
+    }
 }
 
 .grav-editor-content {

--- a/themes/grav/templates/forms/fields/editor/editor.html.twig
+++ b/themes/grav/templates/forms/fields/editor/editor.html.twig
@@ -21,9 +21,9 @@
                 }
             </style>
         {% endif %}
-        
+
         {# Embed Grav Editor #}
-        <div class="grav-editor-content">
+        <div class="grav-editor-content is-active">
             <textarea
                 data-grav-editor="{{ {'codemirror': codemirrorOptions} | json_encode|e('html_attr') }}"
                 data-grav-editor-mode="editor"


### PR DESCRIPTION
This PR fixes related to one of my PR: https://github.com/getgrav/grav-plugin-admin/pull/1065 which fixes issue #722

Though it worked fine, I found an issue when I tried to switch back from Preview to Content, js switched back the display of the content to block (which I changed to flex in the scss).

This PR fixes that issue and hopefully, nothing else comes up. :smile:

**Note**: I still can't compile the scss and js to match the one in the repository. I ran 'gulp' in /grav-plugin-admin/themes/grav but it generated totally different css files. How do you do it? :smile: