### PR TITLE
Added an option for opening frontend pages in a new tab, in a separate tab (always the same) or in the current tab.

### DIFF
--- a/admin.yaml
+++ b/admin.yaml
@@ -22,6 +22,7 @@ session:
 warnings:
   delete_page: true
 edit_mode: normal
+frontend_pages_target: _blank
 show_github_msg: true
 google_fonts: true
 enable_auto_updates_check: true

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -125,6 +125,16 @@ form:
         expert: Expert
       help: Auto will use blueprint if available, if none found, it will use "Expert" mode.
 
+    frontend_pages_target:
+      type: select
+      label: Open frontend pages in
+      size: medium
+      default: _blank
+      options:
+        _blank: New tab
+        frontend_tab: Separate tab (always the same)
+        _self: Current tab
+
     google_fonts:
       type: toggle
       label: Use Google Fonts
@@ -354,5 +364,3 @@ form:
       type: hidden
       label: Visitors history
       default: 20
-
-

--- a/themes/grav/templates/pages.html.twig
+++ b/themes/grav/templates/pages.html.twig
@@ -42,7 +42,8 @@
 {% endblock %}
 
 {% set preview_html = (base_url_relative_frontend|rtrim('/') ~ (context.home ? '' : context.route)) ?: '/' %}
-{% set preview_link = context.routable ? '<a class="button" target="_blank" href="' ~ preview_html ~ '"> <i class="fa fa-fw fa-eye" style="font-size:18px;margin-right:0;"></i></a>' : '' %}
+{% set preview_target = config.plugins.admin.frontend_pages_target %}
+{% set preview_link = context.routable ? '<a class="button" target="' ~ preview_target ~ '" href="' ~ preview_html ~ '"> <i class="fa fa-fw fa-eye" style="font-size:18px;margin-right:0;"></i></a>' : '' %}
 
 {% macro loop(page, depth, twig_vars) %}
     {% set separator = twig_vars['config'].system.param_sep %}


### PR DESCRIPTION
This new option gives you more control over the "eye" button behaviour. This is particularly useful to users complaining about the fact that a new tab is created every time you click on the button.

![capture d ecran 2017-04-26 a 16 57 36](https://cloud.githubusercontent.com/assets/22176950/25456827/07978288-2aa2-11e7-835f-0f0c3e6de216.png)
![capture d ecran 2017-04-26 a 16 56 29](https://cloud.githubusercontent.com/assets/22176950/25456834/0b327bdc-2aa2-11e7-8b2c-0b124172d2dc.png)
