### PR TITLE
Bugfix: Save in wrong lang when multiple tabs open

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -585,9 +585,8 @@ class AdminPlugin extends Plugin
         // Initialize Admin Language if needed
         /** @var Language $language */
         $language = $this->grav['language'];
-        $this->grav['session']->admin_lang = $language->getActive();
-        if ($language->enabled() && empty($this->grav['session']->admin_lang)) {
-            $this->grav['session']->admin_lang = $language->getLanguage();
+        if ($language->enabled()) {
+            $this->grav['session']->admin_lang = $language->getActive();
         }
 
         // Decide admin template and route.

--- a/admin.php
+++ b/admin.php
@@ -585,6 +585,7 @@ class AdminPlugin extends Plugin
         // Initialize Admin Language if needed
         /** @var Language $language */
         $language = $this->grav['language'];
+        $this->grav['session']->admin_lang = $language->getActive();
         if ($language->enabled() && empty($this->grav['session']->admin_lang)) {
             $this->grav['session']->admin_lang = $language->getLanguage();
         }


### PR DESCRIPTION
English and french in this PR are used only for example purposes.

When you have multiple tabs opened in different languages, when you save, it often cause to overwrite the french contents with the english contents (or vice-versa, or according to your specific language configuration).

How to reproduce the bug :

1. Open a tab and edit a page in french
2. In another tab, open the same page in english then save
3. Return to the french tab and save
4. **The english contents got overwrited by the french contents**

This patch makes the use of the language code in URL instead of the session when editing a page, preventing to overwrite the contents of another language while power-editing with many tabs in different languages.