### PR TITLE
Feature custom page options

### DIFF
--- a/classes/admincontroller.php
+++ b/classes/admincontroller.php
@@ -655,7 +655,12 @@ class AdminController extends AdminBaseController
         }
 
         $route  = $data['route'] != '/' ? $data['route'] : '';
-        $folder = ltrim($data['folder'], '_');
+        $folder = $data['folder'];
+        // Handle @slugify-{field} value, automatically slugifies the specified field
+        if (substr($folder, 0, 9) == '@slugify-') {
+            $folder = \Grav\Plugin\Admin\Utils::slug($data[substr($folder, 9)]);
+        }
+        $folder = ltrim($folder, '_');
         if (!empty($data['modular'])) {
             $folder = '_' . $folder;
         }

--- a/classes/utils.php
+++ b/classes/utils.php
@@ -35,4 +35,26 @@ class Utils
         // If a User with the provided email cannot be found, then load user with that email as the username
         return User::load($email);
     }
+
+    /**
+     * Generates a slug of the given string
+     *
+     * @param string $str
+     * @return string
+     */
+    public static function slug($str)
+    {
+        if (function_exists('transliterator_transliterate')) {
+            $str = transliterator_transliterate('Any-Latin; NFD; [:Nonspacing Mark:] Remove; NFC; [:Punctuation:] Remove;', $str);
+        } else {
+            $str = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $str);
+        }
+
+        $str = strtolower($str);
+        $str = preg_replace('/[-\s]+/', '-', $str);
+        $str = preg_replace('/[^a-z0-9-]/i', '', $str);
+        $str = trim($str, '-');
+
+        return $str;
+    }
 }

--- a/themes/grav/templates/pages.html.twig
+++ b/themes/grav/templates/pages.html.twig
@@ -114,6 +114,12 @@
         {% if mode == 'list' %}
             <a class="button" href="{{ base_url }}"><i class="fa fa-reply"></i> {{ "PLUGIN_ADMIN.BACK"|tu }}</a>
 
+            {% for key, add_modal in config.plugins.admin.add_modals %}
+                {% if add_modal.show_in|defined('bar') == 'bar' %}
+                    <a class="button {{ add_modal.link_classes }}" href="#modal-add_modal-{{ key }}" data-remodal-target="modal-add_modal-{{ key }}"><i class="fa fa-plus"></i> {{ add_modal.label }}</a>
+                {% endif %}
+            {% endfor %}
+
             <div class="button-group">
                 <button type="button" class="button disabled" href="#modal" data-remodal-target="modal">
                     <i class="fa fa-plus"></i> {{ "PLUGIN_ADMIN.ADD"|tu }}
@@ -127,6 +133,11 @@
                     {% if admin.modularTypes is not empty %}
                         <li><a class="button" href="#modular" data-remodal-target="modular">{{ "PLUGIN_ADMIN.ADD_MODULAR"|tu }}</a></li>
                     {% endif %}
+                    {% for key, add_modal in config.plugins.admin.add_modals %}
+                        {% if add_modal.show_in|defined('bar') == 'dropdown' %}
+                            <li><a class="button {{ add_modal.link_classes }}" href="#modal-add_modal-{{ key }}" data-remodal-target="modal-add_modal-{{ key }}">{{ add_modal.label }}</a></li>
+                        {% endif %}
+                    {% endfor %}
                 </ul>
             </div>
 
@@ -319,6 +330,12 @@
     <div class="remodal" data-remodal-id="modular" data-remodal-options="hashTracking: false">
         {% include 'partials/blueprints-new.html.twig' with { blueprints: admin.blueprints('admin/pages/modular_new'), data: obj_data } %}
     </div>
+
+    {% for key, add_modal in config.plugins.admin.add_modals %}
+        <div class="remodal {{ add_modal.modal_classes|defined('') }}" data-remodal-id="modal-add_modal-{{ key }}" data-remodal-options="hashTracking: false">
+            {% include add_modal.template|defined('partials/blueprints-new.html.twig') with { blueprints: admin.blueprints(add_modal.blueprint), data: context }|merge(add_modal.with|defined({})) %}
+        </div>
+    {% endfor %}
     {% endif %}
 
 


### PR DESCRIPTION
Related issue: https://github.com/getgrav/grav-plugin-admin/issues/1066

To avoid using JS, I added a custom value handling to 'folder' field: `@slugify-field`
If you want to automatically slugify the title and use it as your folder, just put `default: @slugify-title` to the folder field.

Possible values for `add_modals`:

- **label** - Text to be shown in the button
- **show_in** (default: bar) (values: bar|dropdown) - Determines whether to show the button in the **bar** or **dropdown**
- **blueprint** - Form blueprint to pass to modal template
- **template** - Template to use for modal (default: partials/blueprints-new.html.twig)
- **with** - Extra data for template
- **link_classes** - This will be added to the link's (button in bar) class attribute
- **modal_classes** - This will be added to the modal's class attribute

## Example
This example adds an "Add Post" button which only accepts one value, the title. Automatically puts it into the `/posts`. (You can find more examples and explanation in the https://github.com/getgrav/grav-plugin-admin/issues/1066)

**user/blueprints/admin/pages/new_post.yaml**
```yaml
form:
  validation: loose
  fields:
    section:
        type: section
        title: Add Post

    title:
      type: text
      label: Post Title
      validate:
        required: true

    folder:
      type: hidden
      default: '@slugify-title'

    route:
      type: hidden
      default: /posts

    name:
      type: hidden
      default: 'post'

    visible:
      type: hidden
      default: ''

    blueprint:
      type: blueprint
```

**user/config/plugins/admin.yaml**
```yaml
add_modals:
  post:
    label: Add Post
    blueprint: admin/pages/new_post
    show_in: dropdown
```