### PR TITLE
Feature/page types events

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -816,6 +816,13 @@ class AdminPlugin extends Plugin
     {
         $types = Pages::types();
 
+        // First filter by configuration
+        $hideTypes = Grav::instance()['config']->get('plugins.admin.hide_page_types', []);
+        foreach ($hideTypes as $type) {
+            unset($types[$type]);
+        }
+
+        // Allow manipulating of the data by event
         $e = new Event(['types' => &$types]);
         Grav::instance()->fireEvent('onAdminPageTypes', $e);
 
@@ -834,6 +841,13 @@ class AdminPlugin extends Plugin
     {
         $types = Pages::modularTypes();
 
+        // First filter by configuration
+        $hideTypes = Grav::instance()['config']->get('plugins.admin.hide_modular_page_types', []);
+        foreach ($hideTypes as $type) {
+            unset($types[$type]);
+        }
+
+        // Allow manipulating of the data by event
         $e = new Event(['types' => &$types]);
         Grav::instance()->fireEvent('onAdminModularPageTypes', $e);
 

--- a/admin.php
+++ b/admin.php
@@ -804,4 +804,42 @@ class AdminPlugin extends Plugin
         $admin->addPermissions($permissions);
     }
 
+    /**
+     * Helper function to replace Pages::Types()
+     * and to provide an event to manipulate the data
+     *
+     * Dispatches 'onAdminPageTypes' event
+     * with 'types' data member which is a
+     * reference to the data
+     */
+    public static function pagesTypes()
+    {
+        $types = Pages::types();
+
+        $e = new Event();
+        $e->types = &$types;
+        Grav::instance()->fireEvent('onAdminPageTypes', $e);
+
+        return $types;
+    }
+
+    /**
+     * Helper function to replace Pages::modularTypes()
+     * and to provide an event to manipulate the data
+     *
+     * Dispatches 'onAdminModularPageTypes' event
+     * with 'types' data member which is a
+     * reference to the data
+     */
+    public static function pagesModularTypes()
+    {
+        $types = Pages::modularTypes();
+
+        $e = new Event();
+        $e->types = &$types;
+        Grav::instance()->fireEvent('onAdminModularPageTypes', $e);
+
+        return $types;
+    }
+
 }

--- a/admin.php
+++ b/admin.php
@@ -816,8 +816,7 @@ class AdminPlugin extends Plugin
     {
         $types = Pages::types();
 
-        $e = new Event();
-        $e->types = &$types;
+        $e = new Event(['types' => &$types]);
         Grav::instance()->fireEvent('onAdminPageTypes', $e);
 
         return $types;
@@ -835,8 +834,7 @@ class AdminPlugin extends Plugin
     {
         $types = Pages::modularTypes();
 
-        $e = new Event();
-        $e->types = &$types;
+        $e = new Event(['types' => &$types]);
         Grav::instance()->fireEvent('onAdminModularPageTypes', $e);
 
         return $types;

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -196,6 +196,16 @@ form:
         type: bool
       help: Ask the user confirmation when deleting a page
 
+    hide_page_types:
+      type: array
+      label: Hide page types in Admin
+      value_only: true
+
+    hide_modular_page_types:
+      type: array
+      label: Hide modular page types in Admin
+      value_only: true
+
     Dashboard:
       type: section
       title: Dashboard

--- a/blueprints/admin/pages/modular_new.yaml
+++ b/blueprints/admin/pages/modular_new.yaml
@@ -38,7 +38,7 @@ form:
       label: PLUGIN_ADMIN.MODULAR_TEMPLATE
       help: PLUGIN_ADMIN.PAGE_FILE_HELP
       default: default
-      data-options@: '\Grav\Common\Page\Pages::modularTypes'
+      data-options@: '\Grav\Plugin\AdminPlugin::pagesModularTypes'
       validate:
         required: true
 

--- a/blueprints/admin/pages/modular_raw.yaml
+++ b/blueprints/admin/pages/modular_raw.yaml
@@ -86,7 +86,7 @@ form:
                       classes: fancy
                       label: PLUGIN_ADMIN.MODULAR_TEMPLATE
                       default: default
-                      data-options@: '\Grav\Common\Page\Pages::modularTypes'
+                      data-options@: '\Grav\Plugin\AdminPlugin::pagesModularTypes'
                       validate:
                         required: true
 

--- a/blueprints/admin/pages/new.yaml
+++ b/blueprints/admin/pages/new.yaml
@@ -39,7 +39,7 @@ form:
       classes: fancy
       label: PLUGIN_ADMIN.PAGE_FILE
       help: PLUGIN_ADMIN.PAGE_FILE_HELP
-      data-options@: '\Grav\Common\Page\Pages::types'
+      data-options@: '\Grav\Plugin\AdminPlugin::pagesTypes'
       data-default@: '\Grav\Plugin\Admin\Admin::getLastPageName'
       validate:
         required: true

--- a/blueprints/admin/pages/raw.yaml
+++ b/blueprints/admin/pages/raw.yaml
@@ -87,7 +87,7 @@ form:
                       label: PLUGIN_ADMIN.DISPLAY_TEMPLATE
                       help: PLUGIN_ADMIN.DISPLAY_TEMPLATE_HELP
                       default: default
-                      data-options@: '\Grav\Common\Page\Pages::types'
+                      data-options@: '\Grav\Plugin\AdminPlugin::pagesTypes'
                       validate:
                         required: true
 


### PR DESCRIPTION
Related to issue https://github.com/getgrav/grav-plugin-admin/issues/1020

Adds two new events:

- onAdminPageTypes
- onAdminModularPageTypes

Both events have a `types` data attached to the `event` object which references the types data array. With these events, we can manipulate the data thus provide functionalities like hiding templates.

Example
```php
public static function getSubscribedEvents() {
  return [
    'onAdminPageTypes' => ['onAdminPageTypes', 0],
    'onAdminModularPageTypes' => ['onAdminModularPageTypes', 0],
  ];
}

public function onAdminPageTypes($e) {
  $types = $e['types'];
  unset($types['default']);
  $e['types'] = $types;
}

public function onAdminModularPageTypes($e) {
  $types = $e['types'];
  unset($types['somethingyouwanttoremove']);
  $e['types'] = $types;
}
```

Built-in hiding via configuration:
```yaml
hide_page_types:
  - modular
  - error
hide_modular_page_types:
  - modular/text
```

These can be configured manually or via the admin panel's plugin configuration.
