### PR TITLE
Allow different field to be used as page label in list of pages

### DIFF
--- a/admin.yaml
+++ b/admin.yaml
@@ -26,6 +26,7 @@ warnings:
 edit_mode: normal
 frontend_pages_target: _blank
 show_github_msg: true
+pages_list_display_field: title
 google_fonts: true
 enable_auto_updates_check: true
 notifications:

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -173,6 +173,12 @@ form:
         type: bool
       help: Show the "Found an issue? Please report it on GitHub." message.
 
+    pages_list_display_field:
+      type: text
+      size: small
+      label: Pages List Display Field
+      help: "Field of the page to use in the list of pages if present. Defaults/Fallback to title."
+
     enable_auto_updates_check:
       type: toggle
       label: Automatically check for updates

--- a/themes/grav/templates/pages.html.twig
+++ b/themes/grav/templates/pages.html.twig
@@ -47,6 +47,7 @@
 
 {% macro loop(page, depth, twig_vars) %}
     {% set separator = twig_vars['config'].system.param_sep %}
+    {% set display_field = twig_vars['config'].plugins.admin.pages_list_display_field|defined('title') %}
     {% set base_url = twig_vars['base_url_relative'] %}
     {% set base_url_simple = twig_vars['base_url_simple'] %}
     {% set admin_route = twig_vars['admin_route'] %}
@@ -84,7 +85,8 @@
                 <div class="page-item__content">
                     <div class="page-item__content-name">
                         <span data-hint="{{ description|trim(' &bull; ')|raw }}" class="hint--top page-item__content-hint">
-                            <a href="{{ page_url }}" class="page-edit">{{ p.title|e }}</a>
+                            {% set page_label = attribute(p.header, display_field)|defined(attribute(p, display_field))|defined(p.title) %}
+                            <a href="{{ page_url }}" class="page-edit">{{ page_label|e }}</a>
                         </span>
                         {% if p.language %}
                             <span class="badge lang {% if p.language == admin_lang %}info{% endif %}">{{p.language}}</span>

--- a/themes/grav/templates/pages.html.twig
+++ b/themes/grav/templates/pages.html.twig
@@ -47,7 +47,7 @@
 
 {% macro loop(page, depth, twig_vars) %}
     {% set separator = twig_vars['config'].system.param_sep %}
-    {% set display_field = twig_vars['config'].plugins.admin.pages_list_display_field|defined('title') %}
+    {% set display_field = twig_vars['config'].plugins.admin.pages_list_display_field %}
     {% set base_url = twig_vars['base_url_relative'] %}
     {% set base_url_simple = twig_vars['base_url_simple'] %}
     {% set admin_route = twig_vars['admin_route'] %}


### PR DESCRIPTION
From the documentation and my current understaning the `title` field is used display the page, and the `menu` field is used for navigational purposes.

When a content editor is navigating the pages in the admin plugin using the `menu` field also provides an easy option to give more useful information, e.g. in a long list of child pages.

I'm happy to do this change in more places where this concern might be present, but I know to little about the overall structure of the admin plugin to search by myself.

This could of course also be a configurable option, but as `menu` falls back to `title` it shouldn't do to much harm.  
(I just had the idea of checking if the `title` is contained in `menu` and displaying both if not...)

Any feedback is welcome.