### PR TITLE
fix typo in PLUGIN_ADMIN.LEGEND for 'de'

### DIFF
--- a/languages/de.yaml
+++ b/languages/de.yaml
@@ -568,7 +568,7 @@ PLUGIN_ADMIN:
   THUMB: "Vorschaubild"
   TYPE: "Typ"
   FILE_EXTENSION: "Dateiendung"
-  LEGEND: "Seiten Lengende"
+  LEGEND: "Seitenlegende"
   MEMCACHE_SERVER: "Memcache Server"
   MEMCACHE_SERVER_HELP: "Die Memcache-Server-Adresse"
   MEMCACHE_PORT: "Memcache Port"


### PR DESCRIPTION
There was a typo in `PLUGIN_ADMIN.LEGEND` ("Le**n**gende" instead of "Legende"). Also, words are connected as lower case without a space in German (except proper names, they are usually connected with dashes).