### PR TITLE
Search pages by slug and folder name too

### DIFF
--- a/classes/admincontroller.php
+++ b/classes/admincontroller.php
@@ -1479,6 +1479,7 @@ class AdminController extends AdminBaseController
                 foreach ($queries as $query) {
                     $query = trim($query);
                     if (stripos($page->getRawContent(), $query) === false && stripos($page->title(),
+                            $query) === false && stripos($page->slug(), \Grav\Plugin\Admin\Utils::slug($query)) === false && stripos($page->folder(),
                             $query) === false
                     ) {
                         $collection->remove($page);


### PR DESCRIPTION
In search bar to search pages not only by title and content, but by slug and folder name too.