### PR TITLE
when checking if page is the home route, also check '/.' as current route

### DIFF
--- a/classes/admincontroller.php
+++ b/classes/admincontroller.php
@@ -492,7 +492,7 @@ class AdminController extends AdminBaseController
                 }
             }
 
-            $parent = $route && $route != '/' && $route != '.' ? $pages->dispatch($route, true) : $pages->root();
+            $parent = $route && $route != '/' && $route != '.' && $route != '/.' ? $pages->dispatch($route, true) : $pages->root();
 
             $original_order = intval(trim($obj->order(), '.'));
 


### PR DESCRIPTION
I was getting error that `null` was being passed as the argument to the `move()` function.

I did a little investigating and on my system, `/.` was the value of `$route` when assigning `$parent`.

I am running ubuntu & php7 on a virtualbox if that makes a difference here?