### PR TITLE
Downgrade babel-loader to v6.x

### DIFF
--- a/themes/grav/package.json
+++ b/themes/grav/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "babel-core": "^6.25.0",
-    "babel-loader": "^7.1.1",
+    "babel-loader": "^6.4.1",
     "babel-polyfill": "^6.23.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-3": "^6.24.1",


### PR DESCRIPTION
Webpack 1.x doesn’t support babel-loader > v6.x. Before this commit, this error was thrown when attempting to build the JS:

	ERROR in ./app/main.js
	Module build failed: TypeError: fileSystem.statSync is not a function
		at module.exports (C:\xampp\htdocs\grav-clean\user\plugins\admin\themes\grav\node_modules\babel-loader\lib\utils\exists.js:7:25)
		at find (C:\xampp\htdocs\grav-clean\user\plugins\admin\themes\grav\node_modules\babel-loader\lib\resolve-rc.js:13:9)
		at Object.module.exports (C:\xampp\htdocs\grav-clean\user\plugins\admin\themes\grav\node_modules\babel-loader\lib\index.js:113:132)

See babel/babel-loader#505 for more details.

What’s necessary after merging this pull request:

1. update `package-lock.json` and `yarn.lock`
2. rebuild the JS
3. check if it works

Webpack 3.x is now stable and around for quite some time. Would you accept a pull request to upgrade to Webpack 3.x in this project?