### PR TITLE
Fix partially cropped last line in markdown editor

### DIFF
--- a/themes/grav/scss/template/_editor.scss
+++ b/themes/grav/scss/template/_editor.scss
@@ -6,8 +6,10 @@
 
     .CodeMirror-scroll {
         margin-right: -36px;
-        padding-bottom: 36px;
         position: static;
+
+        // hide native scrollbar at the bottom
+        padding-bottom: 15px;
     }
 
     .grav-editor-resizer {


### PR DESCRIPTION
In browsers like IE, Edge and Firefox the last line of the markdown editor was cropped due to a higher padding-bottom value, see #1217.

I decreased the value from `36px` to `15px` and now the last line is no longer partially cropped in Firefox, IE and Edge. In Chrome now there’s slightly more padding between the last line and the bottom of the editor than before, but still looks OK in my opinion.

This solution is of course not optimal because it relies on magic numbers in CSS, but I can’t think of a simple better solution.

I haven’t committed the generated CSS.