### PR TITLE
Add support for Latin Extended fonts

### DIFF
--- a/themes/grav/scss/configuration/fonts/_support.scss
+++ b/themes/grav/scss/configuration/fonts/_support.scss
@@ -35,7 +35,7 @@
         }
     }
 
-    @return $url;
+    @return $url + "&subset=latin-ext";
 }
 
 @mixin body-fonts($font) {


### PR DESCRIPTION
The Latin Extended characters, if used, are usually used in conjunction with characters coming purely from the Latin alphabet. This is the case for the Polish language, just to name an example, and most if not all other Slavic languages using the Latin alphabet are likely affected as well. Due to that, I believe that they should be included in the downloads from Google Fonts where possible, since random substitute font appearing in the middle of a word isn't particularly fancy.

I haven't found a guideline containing the information as to whether the compiled CSS should be included, so I haven't compiled it, which seemed like the more sensible choice.