### PR TITLE
Fix editor not clickable in list field

### DIFF
--- a/themes/grav/app/forms/fields/collections.js
+++ b/themes/grav/app/forms/fields/collections.js
@@ -32,7 +32,6 @@ export default class CollectionsField {
                 forceFallback: false,
                 handle: '.collection-sort',
                 animation: 150,
-                filter: '.CodeMirror, .grav-editor-resizer',
                 onUpdate: () => this.reindex(container)
             }));
         });


### PR DESCRIPTION
Editors in lists are not focusable by a click in Chrome, MS Edge an probably some other browsers. Removing the `filter` property from the sortablejs instance resolves this issue and seems to have no other impact on the functionality.

Even without `filter: '.CodeMirror, .grav-editor-resizer'`, dragging inside the editor and dragging the editor resizer sill doesn’t trigger sortablejs, which is desired.

Successfully tested on Chrome 61, Firefox 55, Edge 15 and IE 11.

Fixes #1168