### PR TITLE
Add collapsible attribute to lists

### DIFF
--- a/themes/grav/templates/forms/fields/list/list.html.twig
+++ b/themes/grav/templates/forms/fields/list/list.html.twig
@@ -65,7 +65,7 @@
                 {% if field.fields %}
                 {% for key, val in value %}
                     {% set itemName = name ? name ~ '.' ~ key : key %}
-                    <li data-collection-item="{{ itemName }}" data-collection-key="{{ key }}" class="{{ field.collapsed ? 'collection-collapsed' : '' }}">
+                    <li data-collection-item="{{ itemName }}" data-collection-key="{{ key }}" class="{{ (field.collapsible is empty or field.collapsible) and field.collapsed ? 'collection-collapsed' : '' }}">
                         <div class="collection-sort"><i class="fa fa-fw fa-bars"></i></div>
                         {% for childName, child in field.fields %}
                             {% if childName starts with '.' %}
@@ -101,8 +101,10 @@
                             {% endif %}
                         {% endfor %}
                         <div class="item-actions">
-                            <i class="fa fa-chevron-circle-{{ field.collapsed ? 'right' : 'down' }}" data-action="{{ field.collapsed ? 'expand' : 'collapse' }}"></i>
-                            <br />
+                            {% if field.collapsible is empty or field.collapsible %}
+                                <i class="fa fa-chevron-circle-{{ field.collapsed ? 'right' : 'down' }}" data-action="{{ field.collapsed ? 'expand' : 'collapse' }}"></i>
+                                <br />
+                            {% endif %}
                             <i class="fa fa-trash-o" data-action="delete"></i>
                         </div>
                     </li>
@@ -111,10 +113,12 @@
             </ul>
             {% if fieldControls in ['bottom', 'both'] %}
             <div class="collection-actions">
-                <button class="button" type="button" data-action="expand_all"
-                        {% if field.disabled or isDisabledToggleable %}disabled="disabled"{% endif %}><i class="fa fa-chevron-circle-down"></i> {{ "PLUGIN_ADMIN.EXPAND_ALL"|e|tu }}</button>
-                <button class="button" type="button" data-action="collapse_all"
-                        {% if field.disabled or isDisabledToggleable %}disabled="disabled"{% endif %}><i class="fa fa-chevron-circle-right"></i> {{ "PLUGIN_ADMIN.COLLAPSE_ALL"|e|tu }}</button>
+                {% if field.collapsible is empty or field.collapsible %}
+                    <button class="button" type="button" data-action="expand_all"
+                            {% if field.disabled or isDisabledToggleable %}disabled="disabled"{% endif %}><i class="fa fa-chevron-circle-down"></i> {{ "PLUGIN_ADMIN.EXPAND_ALL"|e|tu }}</button>
+                    <button class="button" type="button" data-action="collapse_all"
+                            {% if field.disabled or isDisabledToggleable %}disabled="disabled"{% endif %}><i class="fa fa-chevron-circle-right"></i> {{ "PLUGIN_ADMIN.COLLAPSE_ALL"|e|tu }}</button>
+                {% endif %}
                 {% if field.sortby %}
                     <button class="button{{ not value|length ? ' hidden' : '' }}" type="button" data-action="sort" data-action-sort="{{ field.sortby }}" data-action-sort-dir="{{ field.sortby_dir|default('asc') }}"
                             {% if field.disabled or isDisabledToggleable %}disabled="disabled"{% endif %}><i class="fa fa-sort-amount-{{ field.sortby_dir|default('asc') }}"></i> {{ btnSortLabel|e|tu }} '{{ field.sortby }}'</button>
@@ -163,8 +167,10 @@
                         {%- endif -%}
                     {%- endfor %}
                     <div class="item-actions">
-                        <i class="fa fa-chevron-circle-down" data-action="collapse"></i>
-                        <br />
+                        {% if field.collapsible is empty or field.collapsible %}
+                            <i class="fa fa-chevron-circle-down" data-action="collapse"></i>
+                            <br />
+                        {% endif %}
                         <i class="fa fa-trash-o" data-action="delete"></i>
                     </div>
                     {%- endif -%}

--- a/themes/grav/templates/forms/fields/list/list.html.twig
+++ b/themes/grav/templates/forms/fields/list/list.html.twig
@@ -101,7 +101,7 @@
                             {% endif %}
                         {% endfor %}
                         <div class="item-actions">
-                            {% if field.collapsible is empty or field.collapsible %}
+                            {% if field.collapsible is not defined or field.collapsible %}
                                 <i class="fa fa-chevron-circle-{{ field.collapsed ? 'right' : 'down' }}" data-action="{{ field.collapsed ? 'expand' : 'collapse' }}"></i>
                                 <br />
                             {% endif %}
@@ -113,7 +113,7 @@
             </ul>
             {% if fieldControls in ['bottom', 'both'] %}
             <div class="collection-actions">
-                {% if field.collapsible is empty or field.collapsible %}
+                {% if field.collapsible is not defined or field.collapsible %}
                     <button class="button" type="button" data-action="expand_all"
                             {% if field.disabled or isDisabledToggleable %}disabled="disabled"{% endif %}><i class="fa fa-chevron-circle-down"></i> {{ "PLUGIN_ADMIN.EXPAND_ALL"|e|tu }}</button>
                     <button class="button" type="button" data-action="collapse_all"
@@ -167,7 +167,7 @@
                         {%- endif -%}
                     {%- endfor %}
                     <div class="item-actions">
-                        {% if field.collapsible is empty or field.collapsible %}
+                        {% if field.collapsible is not defined or field.collapsible %}
                             <i class="fa fa-chevron-circle-down" data-action="collapse"></i>
                             <br />
                         {% endif %}


### PR DESCRIPTION
It doesn't occur to me that collapsing a list with a single field in it has any use aside from looking ugly. Fieldsets already have this, too, so here we go. The attribute defaults to true, so both backward and forward compatibility should be preserved just fine. (well, if an older grav-plugin-admin version tried to load a blueprint with this attribute set to 0, it would just be ignored, I suppose that's nice enough compatibility)