### PR TITLE
Replace a leftover "is empty" check of list's collapsible attribute

### DIFF
--- a/themes/grav/templates/forms/fields/list/list.html.twig
+++ b/themes/grav/templates/forms/fields/list/list.html.twig
@@ -65,7 +65,7 @@
                 {% if field.fields %}
                 {% for key, val in value %}
                     {% set itemName = name ? name ~ '.' ~ key : key %}
-                    <li data-collection-item="{{ itemName }}" data-collection-key="{{ key }}" class="{{ (field.collapsible is empty or field.collapsible) and field.collapsed ? 'collection-collapsed' : '' }}">
+                    <li data-collection-item="{{ itemName }}" data-collection-key="{{ key }}" class="{{ (field.collapsible is not defined or field.collapsible) and field.collapsed ? 'collection-collapsed' : '' }}">
                         <div class="collection-sort"><i class="fa fa-fw fa-bars"></i></div>
                         {% for childName, child in field.fields %}
                             {% if childName starts with '.' %}


### PR DESCRIPTION
Before #1231 was merged, @w00fz mentioned that `is empty` wouldn't work with undefined field.collapsible, and updated the commit. One of the four `is empty` checks has however apparently been omitted, so there's the pull request attempting to correct that.