### PR TITLE
Use system config upload limit instead of form limit

### DIFF
--- a/themes/grav/templates/forms/fields/file/file.html.twig
+++ b/themes/grav/templates/forms/fields/file/file.html.twig
@@ -2,6 +2,7 @@
 {% set defaults = config.plugins.form %}
 {% set files = defaults.files|merge(field|default([])) %}
 {% set limit = not field.multiple ? 1 : files.limit %}
+{% set maxFileSize = config.system.media.upload_limit == 0 ? 1000000 : config.system.media.upload_limit / 1024 / 1024 %}
 
 {% macro bytesToSize(bytes) -%}
     {% spaceless %}
@@ -30,8 +31,7 @@
         {% set files = global.files %}
         {% set config = global.grav.config %}
         {% set route = global.context.route() %}
-
-        {% set type = global.blueprint_type ? global.blueprint_type : global.admin.location ? global.admin.location : 'config' %}
+        {% set type = global.blueprint_type ? global.blueprint_type : (get_class(global.context) == 'Grav\\Common\\Page\\Page' ? 'pages' : global.plugin ? 'plugins' : global.theme ? 'themes' : 'config') %}
 
         {% set blueprint_name = global.blueprints.getFilename %}
         {% if type == 'pages' %}
@@ -59,7 +59,7 @@
     {% set page_can_upload = exists or (type == 'page' and not exists and not (field.destination starts with '@self' or field.destination starts with 'self@')) %}
     {% if type is not defined or page_can_upload %}
 
-    {% set settings = {name: field.name, paramName: (scope ~ field.name)|fieldName ~ (files.multiple ? '[]' : ''), limit: limit, filesize: files.filesize, accept: files.accept} %}
+    {% set settings = {name: field.name, paramName: (scope ~ field.name)|fieldName ~ (files.multiple ? '[]' : ''), limit: limit, filesize: maxFileSize, accept: files.accept} %}
 
     <div class="form-input-wrapper dropzone files-upload {% if field.fancy is not same as(false) %}form-input-file{% endif %} {{ field.size|default('xlarge') }}" data-grav-file-settings="{{ settings|json_encode|e('html_attr') }}" {% if file_url_add %}data-file-url-add="{{ file_url_add }}"{% endif %} {% if file_url_remove %}data-file-url-remove="{{ file_url_remove }}"{% endif %}>
         <input


### PR DESCRIPTION
@rhukster thanks for getting me on the right track from slack.

I found that the admin upload limit was being set with the form plugin limit. The form plugin limit is inaccessible in the admin GUI though. I debated adding that field to the blueprint.yaml file for the form plugin, so that the user could edit it in the admin settings, but decided against that. I thought using the system set value would work best. 

Seems to be working correctly for me now.