### PR TITLE
Limit Parents Levels

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -157,6 +157,12 @@ form:
         folder: Show folder
         fullpath: Show fullpath
 
+    pages.parents_levels:
+      type: text
+      label: Parents Levels
+      size: small
+      help: The number of levels to show in parent select list
+      
     google_fonts:
       type: toggle
       label: Use Google Fonts

--- a/themes/grav/templates/forms/fields/parents/parents.html.twig
+++ b/themes/grav/templates/forms/fields/parents/parents.html.twig
@@ -11,8 +11,10 @@
     {% elseif show_parents == 'fullpath' %}
         {% set show_fullpath_val = true %}
     {% endif %}
+    
+    {% set limit_levels_val = config.get('plugins.admin.pages.parents_levels') %}
 
-    {% set defaults = {show_root:true, show_all:true, show_slug:show_slug_val, show_fullpath:show_fullpath_val, default:last_page_route} %}
+    {% set defaults = {show_root:true, show_all:true, show_slug:show_slug_val, show_fullpath:show_fullpath_val, default:last_page_route, limit_levels:limit_levels_val} %}
     {% set field = field|merge(defaults) %}
     {{ parent() }}
 {% endblock %}


### PR DESCRIPTION
The main beneffit of this PR is to improve the parent selection when you have many pages.

This PR will add a field in blueprint and a limit var to the `parents` field in order to limit the levels of parents to show in admin forms. The parent levels limit filter was already implemented in `pages` field, so there was not much to change to make it work.

Solves part or act as a workarround for these issues:
#735, #902, #906,  #941, #1035 

In the future, this might be improved adding low and high level limits. Also having parents filter by page type would be great, or even adding a header `parent: false` by page basis. But for now this PR helps.
