### PR TITLE
Add extra button to make life more enjoyable :)

### DIFF
--- a/themes/grav/templates/plugins.html.twig
+++ b/themes/grav/templates/plugins.html.twig
@@ -53,6 +53,7 @@
         {% if (installed) %}
         <div class="button-bar">
             <a class="button" href="{{ base_url_relative }}/plugins"><i class="fa fa-arrow-left"></i> {{ "PLUGIN_ADMIN.BACK_TO_PLUGINS"|tu }}</a>
+            <a class="button" href="{{ base_url_relative }}/plugins/install"><i class="fa fa-plus"></i> {{ "PLUGIN_ADMIN.INSTALL_MORE_PLUGINS"|tu }}</a>
             {% include 'plugins/'~admin.route~'-buttons.html.twig' ignore missing %}
             <button class="button" type="submit" name="task" value="save" form="blueprints"><i class="fa fa-check"></i> {{ "PLUGIN_ADMIN.SAVE"|tu }}</button>
         </div>

--- a/themes/grav/templates/plugins.html.twig
+++ b/themes/grav/templates/plugins.html.twig
@@ -53,7 +53,7 @@
         {% if (installed) %}
         <div class="button-bar">
             <a class="button" href="{{ base_url_relative }}/plugins"><i class="fa fa-arrow-left"></i> {{ "PLUGIN_ADMIN.BACK_TO_PLUGINS"|tu }}</a>
-            <a class="button" href="{{ base_url_relative }}/plugins/install"><i class="fa fa-plus"></i> {{ "PLUGIN_ADMIN.INSTALL_MORE_PLUGINS"|tu }}</a>
+            <a class="button" href="{{ base_url_relative }}/plugins/install"><i class="fa fa-plus"></i> {{ "PLUGIN_ADMIN.ADD"|tu }}</a>
             {% include 'plugins/'~admin.route~'-buttons.html.twig' ignore missing %}
             <button class="button" type="submit" name="task" value="save" form="blueprints"><i class="fa fa-check"></i> {{ "PLUGIN_ADMIN.SAVE"|tu }}</button>
         </div>


### PR DESCRIPTION
The process of wanting to install multiple plugins is kinda hard right now, because you'd have to return back to the plugins, and select 'add' again every time you'd want to install a new plugin after previous install..

With the extra button provided, after installing a plugin you can return back to the install section of the admin plugins and install more plugins directly from there without the need to make extra clicks every time.