### PR TITLE
Add support for 'default' and 'options' for taxonomy field

### DIFF
--- a/themes/grav/templates/forms/fields/taxonomy/taxonomy.html.twig
+++ b/themes/grav/templates/forms/fields/taxonomy/taxonomy.html.twig
@@ -1,11 +1,13 @@
 {% set taxonomies = (taxonomies is null ? (field.taxonomies ? field.taxonomies : admin.data('config/site').taxonomies) : taxonomies) %}
 {% set parentname = field.name %}
+{% set options = field.options %}
+{% set default = field.default %}
 
 {% for name in taxonomies %}
 
-    {% set value = array(data.value('header.taxonomy.' ~ name)|default([])) %}
+    {% set value = array(data.value('header.taxonomy.' ~ name)|default(default[name] ?? [])) %}
     {% set sub_taxonomies = attribute(grav.taxonomy.taxonomy, name)|default([])|keys %}
-    {% set list = []|merge(sub_taxonomies)|merge(value)|array_unique %}
+    {% set list = (options[name] ?? [])|merge(sub_taxonomies)|merge(value)|array_unique %}
 
     {% set field = {
         type: 'select',


### PR DESCRIPTION
With this patch user can override in blueprint the taxonomy field to add custom taxonomy values in `default` and `options` attributes.
There is only one catch - when overriding default taxonomy field, with both `default` and `options` attributes, you need to add `validation` attribute with `type: commalist`, as shown in example below. Otherwise, after first save Grav will throw an error at top of the page `Array to string conversion`, and page won't be saved. But after second try, it will be successful. I haven't found why this happens, but adding validation fixes it. I'm guessing that it might be related to #1024.

```
taxonomies:
  fields:
    header.taxonomy:
      default:
        category: ['blog','page']
        tag: ['test']
      options:
        category: ['grav']
      validate:
        type: commalist
```