### PR TITLE
Fix permissions collapsing when editing a user

### DIFF
--- a/themes/grav/scss/preset.scss
+++ b/themes/grav/scss/preset.scss
@@ -1566,5 +1566,9 @@ body .bootstrap-datetimepicker-widget {
     }
 }
 
+.permission-container {
+    overflow: hidden;
+}
+
 // Range-field
 @import "template/modules/input-range";


### PR DESCRIPTION
The text field which shows the permission's name is capped at a specific width which prevents it from taking the remaining width.
This small change makes sure the floating elements are cleared.

Video showing the issue
https://drive.google.com/file/d/1wEkiE3y5ohXxWgCftMe8Mj-RSYS0TAjh/view