### PR TITLE
Fix collapsed noncollapsible list fields

### DIFF
--- a/themes/grav/templates/forms/fields/list/list.html.twig
+++ b/themes/grav/templates/forms/fields/list/list.html.twig
@@ -66,7 +66,7 @@
                 {% set collapsible = field.fields|length > 1 and (field.collapsible is not defined or field.collapsible)  %}
                 {% for key, val in value %}
                     {% set itemName = name ? name ~ '.' ~ key : key %}
-                    <li data-collection-item="{{ itemName }}" data-collection-key="{{ key }}" class="{{ not collapsible and field.collapsed ? 'collection-collapsed' : '' }}">
+                    <li data-collection-item="{{ itemName }}" data-collection-key="{{ key }}" class="{{ collapsible and field.collapsed ? 'collection-collapsed' : '' }}">
                         <div class="collection-sort"><i class="fa fa-fw fa-bars"></i></div>
                         {% for childName, child in field.fields %}
                             {%- if childName == 'value' -%}

--- a/themes/grav/templates/forms/fields/list/list.html.twig
+++ b/themes/grav/templates/forms/fields/list/list.html.twig
@@ -66,7 +66,7 @@
                 {% set collapsible = field.fields|length > 1 and (field.collapsible is not defined or field.collapsible)  %}
                 {% for key, val in value %}
                     {% set itemName = name ? name ~ '.' ~ key : key %}
-                    <li data-collection-item="{{ itemName }}" data-collection-key="{{ key }}" class="{{ not collapsible or field.collapsed ? 'collection-collapsed' : '' }}">
+                    <li data-collection-item="{{ itemName }}" data-collection-key="{{ key }}" class="{{ not collapsible and field.collapsed ? 'collection-collapsed' : '' }}">
                         <div class="collection-sort"><i class="fa fa-fw fa-bars"></i></div>
                         {% for childName, child in field.fields %}
                             {%- if childName == 'value' -%}


### PR DESCRIPTION
The value of `field.collapsed` seems to be true even in the case of collapsible fields, making noncollapsible fields collapsed by default, with no way to expand them. According to a quick test I've done, this should fix that.