### PR TITLE
Update blueprints.yaml

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -328,6 +328,7 @@ form:
       default: 0.8
       validate:
         type: number
+        step: 0.01
       help: The quality to use when resizing an image. Between 0 and 1 value.
 
     Dashboard:


### PR DESCRIPTION
Missing "step" attribute for quality causing Safari browser (I didn't test it on other browsers) uses default step "1" and invalidate the quality input due the default input value is 0.8. This is preventing whole form from submit. Adding the step attribute fixes the bug.