### PR TITLE
Initialize session on setup

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -144,6 +144,7 @@ class AdminPlugin extends Plugin
 
         // Only activate admin if we're inside the admin path.
         if ($this->isAdminPath()) {
+            $this->grav['session']->init();
             $this->active = true;
 
             // Set cache based on admin_cache option


### PR DESCRIPTION
This makes the plugin compatible with `system.session.initialize = false` which makes it possible to have no session cookie (for frontend users) while the admin login still works.

The change seems to work fine, but I'm pretty new to Grav and it is entirely possible that the initialization should happen somewhere in the login or form plugins. Any feedback appreciated.