### PR TITLE
Fix for FILEPICKER fields that are a child field of a list

### DIFF
--- a/classes/adminbasecontroller.php
+++ b/classes/adminbasecontroller.php
@@ -751,7 +751,7 @@ class AdminBaseController
             return false;
         }
 
-        if ($data instanceof Data) {
+        if ($data instanceof Data || method_exists($data, 'blueprints')) {
             $settings = $data->blueprints()->schema()->getProperty($this->post['name']);
         } elseif (method_exists($data, 'getBlueprint')) {
             $settings = $data->getBlueprint()->schema()->getProperty($this->post['name']);


### PR DESCRIPTION
I found that when a Filepicker field has a custom source folder defined, that didn't work when the filepicker was a child field (of a list). The blueprint settings wouldn't be found by this method. My proposed fix is what resolved the issue for me but I am not sure that this is 100% sound and conforms to the Grav paradigm. I'm hoping a correct fix will be included in the next update because I have no idea how I could hook this functionality properly within Grav (I'm new to Grav)