### PR TITLE
Change usage of basename where possible

### DIFF
--- a/classes/admin.php
+++ b/classes/admin.php
@@ -669,10 +669,10 @@ class Admin
             $obj->file = $file;
             $obj->page = $this->grav['pages']->get(dirname($obj->path));
 
-            $filename = pathinfo($obj->title)['filename'];
-            $filename = str_replace(['@3x', '@2x'], '', $filename);
-            if (isset(pathinfo($obj->title)['extension'])) {
-                $filename .= '.' . pathinfo($obj->title)['extension'];
+            $fileInfo = pathinfo($obj->title);
+            $filename = str_replace(['@3x', '@2x'], '', $fileInfo['filename']);
+            if (isset($fileInfo['extension'])) {
+                $filename .= '.' . $fileInfo['extension'];
             }
 
             if ($obj->page && isset($obj->page->media()[$filename])) {

--- a/classes/admin.php
+++ b/classes/admin.php
@@ -170,11 +170,11 @@ class Admin
 
         /** @var \DirectoryIterator $directory */
         foreach (new \DirectoryIterator($path) as $file) {
-            if ($file->isDir() || $file->isDot() || Utils::startsWith($file->getBasename(), '.')) {
+            if ($file->isDir() || $file->isDot() || Utils::startsWith($file->getFilename(), '.')) {
                 continue;
             }
 
-            $lang = basename($file->getBasename(), '.yaml');
+            $lang = $file->getBasename('.yaml');
 
             $languages[$lang] = LanguageCodes::getNativeName($lang);
 
@@ -202,7 +202,7 @@ class Admin
             if ($file->isDir() || !preg_match('/^[^.].*.yaml$/', $file->getFilename())) {
                 continue;
             }
-            $configurations[] = basename($file->getBasename(), '.yaml');
+            $configurations[] = $file->getBasename('.yaml');
         }
 
         return $configurations;

--- a/classes/adminbasecontroller.php
+++ b/classes/adminbasecontroller.php
@@ -368,7 +368,7 @@ class AdminBaseController
 
         // Generate random name if required
         if ($settings->random_name) { // TODO: document
-            $extension          = pathinfo($upload->file->name)['extension'];
+            $extension          = pathinfo($upload->file->name, PATHINFO_EXTENSION);
             $upload->file->name = Utils::generateRandomString(15) . '.' . $extension;
         }
 


### PR DESCRIPTION
`DirectoryIterator::getFilename` returns the same value as `DirectoryIterator::getBasename` (no argument) while being locale safe (See getgrav/grav#2087). `DirectoryIterator::getBasename` calls `basename` using the argument provided and returns the result, so calling `basename` on the result can be replaced with passing the argument to `DirectoryIterator::getBasename`. I replaced one call to `getBasename` with `getFilename` as well as simplifying `basename` calls on `DirectoryIterator::getBasename`. I also simplified some usage of `pathinfo`, another locale aware function.

There is still an issue with locale safety (`basename` is still called by `DirectoryIterator::getBasename`). I have mentioned some possible solutions in my issue to the main Grav repository (getgrav/grav#2084).