### PR TITLE
Revert "Hotfix for admincontroller.php"

### DIFF
--- a/classes/admincontroller.php
+++ b/classes/admincontroller.php
@@ -658,7 +658,7 @@ class AdminController extends AdminBaseController
             // XSS Checks for page content
             $xss_whitelist = $this->grav['config']->get('security.xss_whitelist', 'admin.super');
             if (!$this->admin->authorize($xss_whitelist)) {
-                $check_what = ['header' => $data['header'], 'content' => $data['content'] ?? ''];
+                $check_what = ['header' => $data['header'], 'content' => $data['content']];
                 $results = Security::detectXssFromArray($check_what);
                 if (!empty($results)) {
                     $this->admin->setMessage('<i class="fa fa-ban"></i> ' . $this->admin->translate('PLUGIN_ADMIN.XSS_ONSAVE_ISSUE'),


### PR DESCRIPTION
Reverts getgrav/grav-plugin-admin#1533 just realized this used php7 null coalesce operator.  Develop is still php5.6 compatible. 