### PR TITLE
Fix for user without config_system permissions

### DIFF
--- a/themes/grav/templates/partials/nav.html.twig
+++ b/themes/grav/templates/partials/nav.html.twig
@@ -19,7 +19,7 @@
                 </li>
                 {% if authorize(['admin.configuration', 'admin.super']) %}
                     <li class="{{ (location == 'system' or location == 'site' or location == 'config') ? 'selected' : '' }}">
-                        <a href="{{ base_url_relative }}/config/system"><i class="fa fa-fw fa-wrench"></i><em>{{ "PLUGIN_ADMIN.CONFIGURATION"|tu }}</em></a>
+                        <a href="{{ base_url_relative }}/config/{{ authorize(['admin.configuration_system']) ? 'system' : 'site' }}"><i class="fa fa-fw fa-wrench"></i><em>{{ "PLUGIN_ADMIN.CONFIGURATION"|tu }}</em></a>
                     </li>
                 {% endif %}
                 {% if authorize(['admin.pages', 'admin.super']) %}


### PR DESCRIPTION
When a user doesn't have admin.configuration_system permissions, rather than opening the next tab (site) it just blanks out without a tab open. This simple fix let's it check for system permission and if not add site. Ideally we should check in order:

if not system use site
if not site use media
if not media use info

but I don't see that being required too much as Info is the most likely one for a user to have if not system (since its just the basic site information)