### PR TITLE
Add option to hide modular pages in parent select

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -162,6 +162,18 @@ form:
       label: Parents Levels
       size: small
       help: The number of levels to show in parent select list
+    
+    pages.show_modular:
+      type: toggle
+      label: Modular parents
+      hightlight: 1
+      default: 1
+      options:
+        1: PLUGIN_ADMIN.ENABLED
+        0: PLUGIN_ADMIN.DISABLED
+      validate:
+        type: bool
+      help: Show modular pages in the parent select list
 
     google_fonts:
       type: toggle

--- a/themes/grav/templates/forms/fields/parents/parents.html.twig
+++ b/themes/grav/templates/forms/fields/parents/parents.html.twig
@@ -4,6 +4,7 @@
     {% set last_page_route = admin.page.getLastPageRoute %}
     {% set show_slug_val = true %}
     {% set show_fullpath_val = false %}
+    {% set show_all_val = true %}
 
     {% set show_parents = config.get('plugins.admin.pages.show_parents') %}
     {% if show_parents == 'folder' %}
@@ -14,7 +15,12 @@
     
     {% set limit_levels_val = config.get('plugins.admin.pages.parents_levels') %}
 
-    {% set defaults = {show_root:true, show_all:true, show_slug:show_slug_val, show_fullpath:show_fullpath_val, default:last_page_route, limit_levels:limit_levels_val} %}
+    {% set show_modular_val = config.get('plugins.admin.pages.show_modular') %}
+    {% if show_modular_val == false %}
+        {% set show_all_val = false %}
+    {% endif %}
+
+    {% set defaults = {show_root:true, show_all:show_all_val, show_modular:show_modular_val, show_slug:show_slug_val, show_fullpath:show_fullpath_val, default:last_page_route, limit_levels:limit_levels_val} %}
     {% set field = field|merge(defaults) %}
     {{ parent() }}
 {% endblock %}


### PR DESCRIPTION
Similar to #1298, this PR serves to improve the parent selection in deep page hierarchies.

This adds an option to hide modular pages in the parent select field, which cleans up the field a lot. Modular pages rarely act as parents.