### PR TITLE
Add unauthorized.html.twig that is missing and generating an error

### DIFF
--- a/themes/grav/templates/unauthorized.html.twig
+++ b/themes/grav/templates/unauthorized.html.twig
@@ -1,0 +1,1 @@
+{% extends 'partials/base.html.twig' %}


### PR DESCRIPTION
When a user that is not an administrator tries to access a page that it does not have authorization. An error occurs with the message:

Template "default.html.twig" is not defined in "unauthorized.html.twig" at line 1.

Creating a file with name unauthorized.html.twig and just a line o code solves the problem.
So I did this pull request in order to solve the Bug. It's the first time that I try to made a pull request, if I do something wrong please let me know and I will fix it.