### PR TITLE
Added class support for the whole container

### DIFF
--- a/themes/grav/templates/forms/fields/fieldset/fieldset.html.twig
+++ b/themes/grav/templates/forms/fields/fieldset/fieldset.html.twig
@@ -1,7 +1,7 @@
 {% extends "forms/field.html.twig" %}
 
 {% block field %}
-  <div class="form-fieldset{% if vertical %} vertical{% endif %}">
+  <div class="form-fieldset{% if vertical %} vertical{% endif %}{% if field.classes is defined %} {{ field.classes }}{% endif %}">
     {% block contents %}
       <input type="checkbox" class="hidden" id="fieldset_collapsible_{{ field.name }}"{% if not field.collapsible or not field.collapsed %} checked="checked"{% endif %} />
 


### PR DESCRIPTION
I copied/pasted the original `{% if field.classes is defined %}class="{{ field.classes }}" {% endif %}` present in the extended template of the form plugin.

Now, adding a "classes:" in the fieldset declaration should generate a correspondant class in the HTML.