### PR TITLE
remove padding to display buttons side by side

### DIFF
--- a/themes/grav/scss/template/_login.scss
+++ b/themes/grav/scss/template/_login.scss
@@ -148,7 +148,7 @@
             bottom: 0;
             left: 0;
             right: 0;
-            padding: 1.5rem 3rem;
+            padding: 1.5rem 0;
 
             .button {
                 margin-bottom: 2px;


### PR DESCRIPTION
reduce padding left and right to avoid buttons are displayed on two lines (in German " Passwort vergessen" and "Anmelden" needs to much space to display the buttons side by side)

before:
![grafik](https://user-images.githubusercontent.com/186256/61059119-c858f200-a3f8-11e9-820b-524629c2584f.png)

after:
![grafik](https://user-images.githubusercontent.com/186256/61059182-e0c90c80-a3f8-11e9-87d7-94fe14bbb99d.png)
