### PR TITLE
Warn user if javascript is disabled

### DIFF
--- a/languages/en.yaml
+++ b/languages/en.yaml
@@ -1,4 +1,5 @@
 PLUGIN_ADMIN:
+  ADMIN_NOSCRIPT_MSG: "Please enable JavaScript in your browser."
   ADMIN_BETA_MSG: "This is a Beta release! Use this in production at your own risk..."
   ADMIN_REPORT_ISSUE: "Found an issue? Please report it on GitHub."
   EMAIL_FOOTER: "<a href=\"http://getgrav.org\">Powered by Grav</a> - The Modern Flat File CMS"

--- a/themes/grav/templates/partials/base-root.html.twig
+++ b/themes/grav/templates/partials/base-root.html.twig
@@ -40,6 +40,10 @@
         {% include 'partials/messages.html.twig' %}
     {% else %}
 
+        {% block noscript %}
+            {% include 'partials/noscript.html.twig' %}
+        {% endblock noscript %}
+
         {% block page %}
         <div class="remodal-bg">
 

--- a/themes/grav/templates/partials/noscript.html.twig
+++ b/themes/grav/templates/partials/noscript.html.twig
@@ -1,0 +1,42 @@
+<style>
+.error-message {
+  background-color: #fce4e4;
+  border: 1px solid #fcc2c3;
+  width: 100%;
+  padding: 20px 30px;
+}
+.error-text {
+  color: #cc0033;
+  font-family: Helvetica, Arial, sans-serif;
+  width: 100%;
+  font-weight: bold;
+  line-height: 20px;
+  text-shadow: 1px 1px rgba(250,250,250,.3);
+}
+.full-height {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+</style>
+
+<div id="noscript" class="full-height">
+    <main id="admin-main" class="full-height">
+        <div id="titlebar" class="titlebar">
+            <h1><i class="fa fa-fw fa-exclamation-triangle"></i>{{ "PLUGIN_ADMIN.ERROR"|tu }}</h1>
+        </div>
+        <div class="full-height">
+                <div class="error-message {% if config.plugins.admin.content_padding %}content-padding{% endif %}">
+                    <span class="error-text">{{ "PLUGIN_ADMIN.ADMIN_NOSCRIPT_MSG"|tu }}</span>
+                </div>
+        </div>
+    </main>
+</div>
+
+<script type="text/javascript">
+  function checkjs() {
+    var element = document.getElementById("noscript");
+    element.style.display = 'none';
+  }
+  checkjs();
+</script>


### PR DESCRIPTION
If a user logs in and javascript is disabled, you won't see any statistics but only the chart loaders.
Also some CSS files (template.css, chartist.min.css etc.) are not loaded (error 404).