### PR TITLE
Fix `accept` for SVG files in `file` uploaders:

### DIFF
--- a/classes/adminbasecontroller.php
+++ b/classes/adminbasecontroller.php
@@ -325,7 +325,7 @@ class AdminBaseController
             }
 
             $isMime = strstr($type, '/');
-            $find   = str_replace(['.', '*'], ['\.', '.*'], $type);
+            $find   = str_replace(['.', '*', '+'], ['\.', '.*', '\+'], $type);
 
             if ($isMime) {
                 $match = preg_match('#' . $find . '$#', $mime);


### PR DESCRIPTION
Using `accept: 'image/svg+xml' to only allow SVG file to be uploaded should now work.

The `preg_match` was comparing `svgggg…xml` with `svg+xml`.

Check the [List of Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml#image) for more potential issues.