### PR TITLE
Add span with required sign to editor field label

### DIFF
--- a/themes/grav/templates/forms/fields/editor/editor.html.twig
+++ b/themes/grav/templates/forms/fields/editor/editor.html.twig
@@ -11,7 +11,10 @@
             {% if field.help %}
                 {% set hint = 'data-hint="' ~ field.help|tu|raw ~ '"' %}
             {% endif %}
-            <div class="form-label form-field hint--bottom" {{ hint|raw }}>{{ field.label|tu|raw }}</div>
+            <div class="form-label form-field hint--bottom" {{ hint|raw }}>
+                {{ field.label|tu|raw }}
+                {{ field.validate.required in ['on', 'true', 1] ? '<span class="required">*</span>' }}
+            </div>
         {% endif %}
     {% endblock %}
     <div class="form-field {{ field.classes|default('') }}">


### PR DESCRIPTION
Currently, the editor field is not marked visibly as mandatory if it is set to required in the blueprint. I added the same span to the label like it is done for other fields.