### PR TITLE
Allow create-option to be used

### DIFF
--- a/themes/grav/templates/forms/fields/selectize/selectize.html.twig
+++ b/themes/grav/templates/forms/fields/selectize/selectize.html.twig
@@ -2,7 +2,7 @@
 
 {% block global_attributes %}
     {% if field.selectize is defined %}
-        {% set fieldSelectize = field.selectize|merge({'create': true}) %}
+        {% set fieldSelectize = field.selectize|merge({'create': field.selectize.create ?? true}) %}
         {% if field.merge_items %}
             {% set fieldSelectize = fieldSelectize|merge({'items':value}) %}
         {% endif %}

--- a/themes/grav/templates/forms/fields/selectize/selectize.html.twig
+++ b/themes/grav/templates/forms/fields/selectize/selectize.html.twig
@@ -2,7 +2,7 @@
 
 {% block global_attributes %}
     {% if field.selectize is defined %}
-        {% set fieldSelectize = field.selectize|merge({'create': field.selectize.create ?? true}) %}
+        {% set fieldSelectize = {create: field.selectize.create ?? true}|merge(field.selectize ?? {}) %}
         {% if field.merge_items %}
             {% set fieldSelectize = fieldSelectize|merge({'items':value}) %}
         {% endif %}


### PR DESCRIPTION
Let the field define the [create](https://github.com/selectize/selectize.js/blob/master/docs/usage.md#general)-option for Selectize.js, defaulting to `true`.