### PR TITLE
Fix data urls used for avatar images

### DIFF
--- a/themes/grav/templates/partials/nav-user-avatar.html.twig
+++ b/themes/grav/templates/partials/nav-user-avatar.html.twig
@@ -1,2 +1,2 @@
 {% set user_avatar = admin.user.getAvatarUrl() %}
-<img src="{{ '?' not in user_avatar ? user_avatar ~ '?s=80' : user_avatar }}" />
+<img src="{{ ('?' not in user_avatar) and (not user_avatar starts with 'data:') ? user_avatar ~ '?s=80' : user_avatar }}" />


### PR DESCRIPTION
data urls containing base64 encoded data break when the size parameter gets added. This fix is needed to display profile pictures from Azure OAuth2 accounts. See trilbymedia/grav-plugin-login-oauth2-extras#3.