### PR TITLE
onAdminAfterDelMedia provides affected media

### DIFF
--- a/classes/admincontroller.php
+++ b/classes/admincontroller.php
@@ -1878,7 +1878,7 @@ class AdminController extends AdminBaseController
 
         $page = $this->admin->page(true);
         if ($page) {
-            $this->grav->fireEvent('onAdminAfterDelMedia', new Event(['page' => $page]));
+            $this->grav->fireEvent('onAdminAfterDelMedia', new Event(['page' => $page, 'media' => $media->getPath() . '/' . $filename]));
         }
 
         $this->admin->json_response = [


### PR DESCRIPTION
When listening on the `onAdminAfterDelMedia` event, we are likely to be more interested by the media itself (eg, to prune caches), than the parent page (which may contain multiple medias).

Passing it won't hurt (and will likely help).