### PR TITLE
Allow enabling folder numeric prefix by default

### DIFF
--- a/admin.yaml
+++ b/admin.yaml
@@ -31,6 +31,7 @@ edit_mode: normal
 frontend_preview_target: inline
 show_github_msg: true
 pages_list_display_field: title
+enable_numeric_prefix: false
 google_fonts: false
 admin_icons: line-awesome
 enable_auto_updates_check: true

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -211,6 +211,18 @@ form:
       label: Pages List Display Field
       help: "Field of the page to use in the list of pages if present. Defaults/Fallback to title."
 
+    enable_numeric_prefix:
+      type: toggle
+      label: Enable Folder Numeric Prefix
+      highlight: 1
+      default: 0
+      options:
+        1: PLUGIN_ADMIN.ENABLED
+        0: PLUGIN_ADMIN.DISABLED
+      validate:
+        type: bool
+      help: "Enables folder numeric prefix for sortable pages by default if a new page has no siblings."
+
     enable_auto_updates_check:
       type: toggle
       label: Automatically check for updates

--- a/classes/admin.php
+++ b/classes/admin.php
@@ -1623,17 +1623,25 @@ class Admin
 
                 // Set the key header value
                 $header = ['title' => $data['title']];
-
+                
                 if (isset($data['visible'])) {
                     if ($data['visible'] === '' || $data['visible']) {
                         // if auto (ie '')
                         $pageParent = $page->parent();
                         $children = $pageParent ? $pageParent->children() : [];
-                        foreach ($children as $child) {
-                            if ($child->order()) {
-                                // set page order
-                                $page->order(AdminController::getNextOrderInFolder($pageParent->path()));
-                                break;
+                        // Check config, enable folder numeric prefix for page with no siblings if option selected
+                        $this->config = Grav::instance()['config'];
+                        $prefix = $this->config->get('plugins.admin.enable_numeric_prefix', false);
+                        if (count($children) < 2 && $prefix) {
+                            $page->order(AdminController::getNextOrderInFolder($pageParent->path()));
+                        }
+                        else {
+                            foreach ($children as $child) {
+                                if ($child->order()) {
+                                    // set page order
+                                    $page->order(AdminController::getNextOrderInFolder($pageParent->path()));
+                                    break;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Related to issue #1185: This allows enabling folder numeric prefix by default for pages with no siblings. While the related issue is only about modular pages, this option applies to all types, as this is a constant annoyance for me. It seems like it can't hurt to at least have an option in the plugin.

By default, the new option is set to false, since that is currently how the plugin operates.

I am happy to update the PR if changes need to be made before merging it.