### PR TITLE
Output raw text in paragraph for fieldset

### DIFF
--- a/themes/grav/templates/forms/fields/fieldset/fieldset.html.twig
+++ b/themes/grav/templates/forms/fields/fieldset/fieldset.html.twig
@@ -50,9 +50,9 @@
           {% block group %}
               {% if field.text %}
                 {% if grav.twig.twig.filters['tu'] is defined %}
-                    {{ field.markdown ? field.text|tu|markdown : '<p>' ~ field.text|tu ~ '</p>' }}
+                    {{ field.markdown ? field.text|tu|markdown : ('<p>' ~ field.text|tu ~ '</p>')|raw }}
                 {% else %}
-                    {{ field.markdown ? field.text|t|markdown : '<p>' ~ field.t ~ '</p>' }}
+                    {{ field.markdown ? field.text|t|markdown : ('<p>' ~ field.t ~ '</p>')|raw }}
                 {% endif %}
               {% endif %}
 


### PR DESCRIPTION
Current behavior will output escaped HTML:

![Escaped HTML in fieldset](https://cdn.discordapp.com/attachments/501854266873348112/763799346851348500/unknown.png)

Not what is expected:

![image](https://user-images.githubusercontent.com/974717/95653402-d06e7880-0af8-11eb-8f34-9ad467a55998.png)

The fallback needs to be filtered as raw, as proposed.