### PR TITLE
Fix bad backups statistics dates on some installation

### DIFF
--- a/themes/grav/templates/partials/tools-backups.html.twig
+++ b/themes/grav/templates/partials/tools-backups.html.twig
@@ -5,9 +5,9 @@
     {% set profiles = grav.backups.getBackupProfiles() %}
     {% set purge_config = grav.backups.getPurgeConfig() %}
     {% set newest_date = (backups|first).date %}
-    {% set newest_backup = newest_date ? newest_date|nicetime(false, false) : 'none' %}
+    {% set newest_backup = newest_date ? newest_date|adminNicetime : 'none' %}
     {% set oldest_date = (backups|last).date %}
-    {% set oldest_backup = oldest_date ? oldest_date|nicetime(false, false) : 'none' %}
+    {% set oldest_backup = oldest_date ? oldest_date|adminNicetime : 'none' %}
 
     {% switch purge_config.trigger %}
     {% case 'number' %}


### PR DESCRIPTION
Hello,

This PR fix #1763 : on some installations, backups statistics date aren't correctly displayed :
![image](https://user-images.githubusercontent.com/6187125/102554943-09613580-40c6-11eb-89b5-2a49fb57d375.png)

With this PR :
![image](https://user-images.githubusercontent.com/6187125/102554987-23027d00-40c6-11eb-876c-08de3901439d.png)

The twig filter used was created on 94dc1d13f640aeeaffc5b744fdb46514ff292e15 . At this time, the themes/grav/templates/partials/tools-backups.html.twig file doesn't exist.

@rhukster could you please check on your hosting (as you can't replicate the issue) if this PR doesn't break the functionnality ?

Regards,
Anael