### PR TITLE
Allow blueprint creation modals in other pages

### DIFF
--- a/themes/grav/templates/partials/blueprints-new-folder.html.twig
+++ b/themes/grav/templates/partials/blueprints-new-folder.html.twig
@@ -1,7 +1,7 @@
 {% set form_id = form_id ? form_id : 'blueprints' %}
 {% set scope = scope ?: 'data.' %}
 
-<form action="{{ form_action }}" id="{{ form_id }}" method="post" data-grav-form="{{ form_id }}" data-grav-keepalive="true">
+<form {% if form_action %}action="{{ form_action }}"{% endif %} id="{{ form_id }}" method="post" data-grav-form="{{ form_id }}" data-grav-keepalive="true">
     {% for field in blueprints.fields %}
         {% if field.type %}
             {% set value = field.name ? (form.value(field.name) ?? data.value(field.name)) : data.toArray %}

--- a/themes/grav/templates/partials/blueprints-new-folder.html.twig
+++ b/themes/grav/templates/partials/blueprints-new-folder.html.twig
@@ -1,7 +1,7 @@
 {% set form_id = form_id ? form_id : 'blueprints' %}
 {% set scope = scope ?: 'data.' %}
 
-<form id="{{ form_id }}" method="post" data-grav-form="{{ form_id }}" data-grav-keepalive="true">
+<form action="{{ form_action }}" id="{{ form_id }}" method="post" data-grav-form="{{ form_id }}" data-grav-keepalive="true">
     {% for field in blueprints.fields %}
         {% if field.type %}
             {% set value = field.name ? (form.value(field.name) ?? data.value(field.name)) : data.toArray %}

--- a/themes/grav/templates/partials/blueprints-new.html.twig
+++ b/themes/grav/templates/partials/blueprints-new.html.twig
@@ -1,7 +1,7 @@
 {% set form_id = form_id ? form_id : 'blueprints' %}
 {% set scope = scope ?: 'data.' %}
 
-<form id="{{ form_id }}" method="post" data-grav-form="{{ form_id }}" {% if form.novalidate %}novalidate{% endif %} data-grav-keepalive="true">
+<form action="{{ form_action }}" id="{{ form_id }}" method="post" data-grav-form="{{ form_id }}" {% if form.novalidate %}novalidate{% endif %} data-grav-keepalive="true">
     {% for field in blueprints.fields %}
         {% if field.type %}
             {% set value = field.name ? (form.value(field.name) ?? data.value(field.name)) : data.toArray %}

--- a/themes/grav/templates/partials/blueprints-new.html.twig
+++ b/themes/grav/templates/partials/blueprints-new.html.twig
@@ -1,7 +1,7 @@
 {% set form_id = form_id ? form_id : 'blueprints' %}
 {% set scope = scope ?: 'data.' %}
 
-<form action="{{ form_action }}" id="{{ form_id }}" method="post" data-grav-form="{{ form_id }}" {% if form.novalidate %}novalidate{% endif %} data-grav-keepalive="true">
+<form {% if form_action %}action="{{ form_action }}"{% endif %} id="{{ form_id }}" method="post" data-grav-form="{{ form_id }}" {% if form.novalidate %}novalidate{% endif %} data-grav-keepalive="true">
     {% for field in blueprints.fields %}
         {% if field.type %}
             {% set value = field.name ? (form.value(field.name) ?? data.value(field.name)) : data.toArray %}

--- a/themes/grav/templates/partials/blueprints-raw.html.twig
+++ b/themes/grav/templates/partials/blueprints-raw.html.twig
@@ -5,7 +5,7 @@
     {% set multipart = ' enctype="multipart/form-data"' %}
 {% endif %}
 
-<form action="{{ form_action }}" id="{{ form_id }}" method="post" data-grav-form="{{ form_id }}" data-grav-keepalive="true"{{ multipart|raw }}>
+<form {% if form_action %}action="{{ form_action }}"{% endif %} id="{{ form_id }}" method="post" data-grav-form="{{ form_id }}" data-grav-keepalive="true"{{ multipart|raw }}>
     {% for field in blueprints.fields %}
         {% if field.type %}
             {% set value = field.name ? (form.value(field.name) ?? data.value(field.name)) : data.toArray %}

--- a/themes/grav/templates/partials/blueprints-raw.html.twig
+++ b/themes/grav/templates/partials/blueprints-raw.html.twig
@@ -5,7 +5,7 @@
     {% set multipart = ' enctype="multipart/form-data"' %}
 {% endif %}
 
-<form id="{{ form_id }}" method="post" data-grav-form="{{ form_id }}" data-grav-keepalive="true"{{ multipart|raw }}>
+<form action="{{ form_action }}" id="{{ form_id }}" method="post" data-grav-form="{{ form_id }}" data-grav-keepalive="true"{{ multipart|raw }}>
     {% for field in blueprints.fields %}
         {% if field.type %}
             {% set value = field.name ? (form.value(field.name) ?? data.value(field.name)) : data.toArray %}

--- a/themes/grav/templates/partials/blueprints.html.twig
+++ b/themes/grav/templates/partials/blueprints.html.twig
@@ -7,7 +7,7 @@
     {% set multipart = ' enctype="multipart/form-data"' %}
 {% endif %}
 
-<form action="{{ form_action }}" id="{{ form_id }}" method="post" data-grav-form="{{ form_id }}" {% if form.novalidate %}novalidate{% endif %} data-grav-keepalive="true"{{ multipart|raw }}>
+<form {% if form_action %}action="{{ form_action }}"{% endif %} id="{{ form_id }}" method="post" data-grav-form="{{ form_id }}" {% if form.novalidate %}novalidate{% endif %} data-grav-keepalive="true"{{ multipart|raw }}>
     {% for field in blueprints.fields %}
         {% if field.type %}
             {% set value = field.name ? (form.value(field.name) ?? data.value(field.name)) : data.toArray %}

--- a/themes/grav/templates/partials/blueprints.html.twig
+++ b/themes/grav/templates/partials/blueprints.html.twig
@@ -7,7 +7,7 @@
     {% set multipart = ' enctype="multipart/form-data"' %}
 {% endif %}
 
-<form id="{{ form_id }}" method="post" data-grav-form="{{ form_id }}" {% if form.novalidate %}novalidate{% endif %} data-grav-keepalive="true"{{ multipart|raw }}>
+<form action="{{ form_action }}" id="{{ form_id }}" method="post" data-grav-form="{{ form_id }}" {% if form.novalidate %}novalidate{% endif %} data-grav-keepalive="true"{{ multipart|raw }}>
     {% for field in blueprints.fields %}
         {% if field.type %}
             {% set value = field.name ? (form.value(field.name) ?? data.value(field.name)) : data.toArray %}


### PR DESCRIPTION
I have added the possibility to set a form action for the blueprint partials.
This way you can eg. add a "Add page" button to another admin page and define the form being sent to `admin_route('pages')`. If no `form_action` parameter is passed, the value is empty and the form will be sent to self.