### PR TITLE
Add item at the top if top button is clicked in list field

### DIFF
--- a/themes/grav/templates/forms/fields/list/list.html.twig
+++ b/themes/grav/templates/forms/fields/list/list.html.twig
@@ -56,7 +56,7 @@
                         <button class="button{{ not value|length ? ' hidden' : '' }}" type="button" data-action="sort" data-action-sort="{{ field.sortby }}" data-action-sort-dir="{{ field.sortby_dir|default('asc') }}"
                                 {% if field.disabled or isDisabledToggleable %}disabled="disabled"{% endif %}><i class="fa fa-sort-amount-{{ field.sortby_dir|default('asc') }}"></i> {{ btnSortLabel|e|tu }} '{{ field.sortby }}'</button>
                     {% endif %}
-                    <button class="button" type="button" data-action="add" data-action-add="bottom"
+                    <button class="button" type="button" data-action="add" data-action-add="top"
                             {% if field.disabled or isDisabledToggleable %}disabled="disabled"{% endif %}><i class="fa fa-plus"></i> {{ btnLabel|e|tu }}</button>
                 </div>
             {% endif %}

--- a/themes/grav/templates/forms/fields/list/list.html.twig
+++ b/themes/grav/templates/forms/fields/list/list.html.twig
@@ -56,8 +56,10 @@
                         <button class="button{{ not value|length ? ' hidden' : '' }}" type="button" data-action="sort" data-action-sort="{{ field.sortby }}" data-action-sort-dir="{{ field.sortby_dir|default('asc') }}"
                                 {% if field.disabled or isDisabledToggleable %}disabled="disabled"{% endif %}><i class="fa fa-sort-amount-{{ field.sortby_dir|default('asc') }}"></i> {{ btnSortLabel|e|tu }} '{{ field.sortby }}'</button>
                     {% endif %}
-                    <button class="button" type="button" data-action="add" data-action-add="top"
-                            {% if field.disabled or isDisabledToggleable %}disabled="disabled"{% endif %}><i class="fa fa-plus"></i> {{ btnLabel|e|tu }}</button>
+                    <button class="button" type="button" data-action="add"
+                            data-action-add="{{ field.placement is same as('position') ? 'top' : field.placement|default('bottom') }}"
+                            {% if field.disabled or isDisabledToggleable %}disabled="disabled"{% endif %}
+                    ><i class="fa fa-plus"></i> {{ btnLabel|e|tu }}</button>
                 </div>
             {% endif %}
             <ul  {% if field.classes is defined %}class="{{ field.classes }}"{% endif %} data-collection-holder="{{ name }}"
@@ -131,8 +133,10 @@
                     <button class="button{{ not value|length ? ' hidden' : '' }}" type="button" data-action="sort" data-action-sort="{{ field.sortby }}" data-action-sort-dir="{{ field.sortby_dir|default('asc') }}"
                             {% if field.disabled or isDisabledToggleable %}disabled="disabled"{% endif %}><i class="fa fa-sort-amount-{{ field.sortby_dir|default('asc') }}"></i> {{ btnSortLabel|e|tu }} '{{ field.sortby }}'</button>
                 {% endif %}
-                <button class="button" type="button" data-action="add" data-action-add="bottom"
-                        {% if field.disabled or isDisabledToggleable %}disabled="disabled"{% endif %}><i class="fa fa-plus"></i> {{ btnLabel|e|tu }}</button>
+                <button class="button" type="button" data-action="add"
+                        data-action-add="{{ field.placement is same as('position') ? 'bottom' : field.placement|default('bottom') }}"
+                        {% if field.disabled or isDisabledToggleable %}disabled="disabled"{% endif %}
+                ><i class="fa fa-plus"></i> {{ btnLabel|e|tu }}</button>
             </div>
             {% endif %}
 
@@ -192,4 +196,3 @@
         </div>
     </div>
 {% endblock %}
-

--- a/themes/grav/templates/forms/fields/list/list.html.twig
+++ b/themes/grav/templates/forms/fields/list/list.html.twig
@@ -196,3 +196,4 @@
         </div>
     </div>
 {% endblock %}
+


### PR DESCRIPTION
Pretty much title says it all. IMO it makes much more sense, that top button would add item at the top, because if list is long enough, you are not even seeing if something happens when item is added at the bottom. Created this PR because of [the question asked in forum](https://discourse.getgrav.org/t/blueprint-type-list-new-data-on-top-of-array/15254). Also created same change [PR for Flex Objects plugin](https://github.com/trilbymedia/grav-plugin-flex-objects/pull/105)

So the solution would be either like this PR suggests, or button actions should be configurable via Admin config somewhere.