### PR TITLE
Fix side-tabs navigation in page edit

### DIFF
--- a/themes/grav/scss/template/_tabs.scss
+++ b/themes/grav/scss/template/_tabs.scss
@@ -6,7 +6,14 @@ $tab-label-height: 50px;
     .admin-pages &:first-child {
         margin-top: -1rem;
     }
+    
     .admin-pages & {
+        &.side-tabs {
+            .tabs-nav {
+                margin-right: 0 !important;
+            }
+        }
+
         .tabs-nav {
             margin-right: 180px;
 


### PR DESCRIPTION
By default, tabs-nav as side-tabs on edit page has redundant margin (this margin is added to all tabs-nav, to have space for `Normal | Expert` buttons on the right side in top - horizontal tabs-nav), but for side-tabs it's not needed.
This PR fix this issue.

![image](https://user-images.githubusercontent.com/6519351/114621742-5dafa700-9cad-11eb-84c1-a5945c47ed05.png)
