### PR TITLE
Add logic to allow fieldset form field inside a list field

### DIFF
--- a/themes/grav/templates/forms/fields/list/list.html.twig
+++ b/themes/grav/templates/forms/fields/list/list.html.twig
@@ -105,11 +105,17 @@
                                 %}
                             {% elseif child.type %}
                                 {% set originalValue = childValue %}
+                                {% set templateData = { field: child, value: childValue } %}
+
+                                {% if child.type == 'fieldset' %}
+                                    {% set templateData = templateData|merge({val: childValue}) %}
+                                {% endif %}
+
                                 {%
                                     include [
-                                        "forms/fields/#{child.type}/#{child.type}.html.twig",
-                                        'forms/fields/text/text.html.twig'
-                                    ] with { field: child, value: childValue }
+                                    "forms/fields/#{child.type}/#{child.type}.html.twig",
+                                    'forms/fields/text/text.html.twig'
+                                    ] with templateData
                                 %}
                             {% endif %}
                         {% endfor %}

--- a/themes/grav/templates/forms/fields/list/list.html.twig
+++ b/themes/grav/templates/forms/fields/list/list.html.twig
@@ -113,8 +113,8 @@
 
                                 {%
                                     include [
-                                    "forms/fields/#{child.type}/#{child.type}.html.twig",
-                                    'forms/fields/text/text.html.twig'
+                                        "forms/fields/#{child.type}/#{child.type}.html.twig",
+                                        'forms/fields/text/text.html.twig'
                                     ] with templateData
                                 %}
                             {% endif %}


### PR DESCRIPTION
Nested fields are passing `val` into child templates. Because it becomes a nested field in another nested field (`fieldset` inside a `list`), we need to reset `val` to a deeper level.

Example usage:
```yaml
# /blueprints/some-plugin.yaml
header.image_comparers:
  type: list
  label: PLUGIN_THREE_WAY_IMAGE_COMPARER.COMPARERS.LABEL
  collapsed: false
  controls: both
  placement: position

  fields:

    .before:
      type: fieldset
      title: PLUGIN_THREE_WAY_IMAGE_COMPARER.COMPARERS.BEFORE.LABEL
      collapsed: false
      collapsible: true

      fields:

        .text:
          type: text
          label: PLUGIN_THREE_WAY_IMAGE_COMPARER.COMPARERS.TEXT

        .image:
          type: filepicker
          preview_images: true
          label: PLUGIN_THREE_WAY_IMAGE_COMPARER.COMPARERS.IMAGE
          on_demand: true

    .middle:
      type: fieldset
      title: PLUGIN_THREE_WAY_IMAGE_COMPARER.COMPARERS.MIDDLE.LABEL
      info: PLUGIN_THREE_WAY_IMAGE_COMPARER.COMPARERS.MIDDLE.DESCRIPTION
      collapsed: true
      collapsible: true

      fields:

        .text:
          type: text
          label: PLUGIN_THREE_WAY_IMAGE_COMPARER.COMPARERS.TEXT

        .image:
          type: filepicker
          preview_images: true
          label: PLUGIN_THREE_WAY_IMAGE_COMPARER.COMPARERS.IMAGE
          on_demand: true

    .after:
      type: fieldset
      title: PLUGIN_THREE_WAY_IMAGE_COMPARER.COMPARERS.AFTER.LABEL
      collapsed: false
      collapsible: true

      fields:

        .text:
          type: text
          label: PLUGIN_THREE_WAY_IMAGE_COMPARER.COMPARERS.TEXT

        .image:
          type: filepicker
          preview_images: true
          label: PLUGIN_THREE_WAY_IMAGE_COMPARER.COMPARERS.IMAGE
          on_demand: true
```

View in Admin
![image](https://user-images.githubusercontent.com/3602819/123490995-43376980-d61e-11eb-8e41-e46e8cf1538e.png)

Saved in frontmatter:
```yaml
image_comparers:
    -
        before:
            text: Prieš
            image: _CRO0953-Edit-copy.jpg
        middle:
            text: Tarp
            image: _CRO0389-Edit-copy.jpg
        after:
            text: Po
            image: _CRO3702-Edit-copy.jpg
    -
        before:
            text: null
            image: _CRO0389-Edit-copy.jpg
        middle:
            text: null
            image: null
        after:
            text: null
            image: _CRO0953-Edit-copy.jpg
```