### PR TITLE
Support random default values for list child fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.10.32
+## mm/dd/2022
+
+1. [](#improved)
+   * List field: Support for default values other than key/value [#2255](https://github.com/getgrav/grav-plugin-admin/issues/2255)
+
 # v1.10.31
 ## 03/14/2022
 

--- a/themes/grav/templates/forms/fields/list/list.html.twig
+++ b/themes/grav/templates/forms/fields/list/list.html.twig
@@ -90,6 +90,10 @@
                                         {% set child_value = val %}
                                     {% else %}
                                         {% set child_value = form ? form.value(child.name) : data.value(child.name) %}
+                                        {# Look for a default value for that field #}
+                                        {% if child_value is null and val[child_name|trim('.', 'left')] is defined %}
+                                          {% set child_value = val[child_name|trim('.', 'left')] %}
+                                        {% endif %}
                                     {% endif %}
 
                                     {% set field_templates = include_form_field(child.type, field_layout, default_layout) %}


### PR DESCRIPTION
At the moment, only fields `key/value` are supported and not a randomly named set of properties.

The trim function is needed, because the field name starts with a dot vs val is without a dot.
The value is assigned in line 3 in `list.twig.html`
(Line 3 is shouldn't be needed because `fields.twig.html` does the same thing. Check for null and assign default)