### PR TITLE
Simplify CSS selectors for blueprint sections for custom admin styling

### DIFF
--- a/themes/grav/templates/forms/fields/section/section.html.twig
+++ b/themes/grav/templates/forms/fields/section/section.html.twig
@@ -3,17 +3,18 @@
 {% block field %}
 {% if field.security is empty or authorize(array(field.security)) %}
 
-    {% if field.title or field.underline %}
-    <h1 class="{{ field.classes }} {{ field.underline ?: 'no_underline' }}">{{ field.title|t }}</h1>
-    {% endif %}
-
-    {% if field.text %}
-    <p>{{ field.text|t|markdown|raw }}</p>
-    {% endif %}
-
     {% embed 'forms/default/fields.html.twig' with {name: field.name, fields: field.fields} %}
         {% block outer_markup_field_open %}
             <div class="form-section {{ field.field_classes }} {{ field.outer_classes }}">
+
+            {% if field.title or field.underline %}
+            <h1 class="{{ field.classes }} {{ field.underline ?: 'no_underline' }}">{{ field.title|t }}</h1>
+            {% endif %}
+
+            {% if field.text %}
+            <div class="section-text">{{ field.text|t|markdown|raw }}</div>
+            {% endif %}
+
         {% endblock %}
         {% block outer_markup_field_close %}
             </div>


### PR DESCRIPTION
The current template provides very few CSS hooks (selector options) so makes it difficult to add custom admin styles.

This does not alter existing default rendering of section fields and provides two styling hooks:

* `.form-section > h1`
* `.form-section .section-text` - in my case I wanted to style this like display fields of a certain class.