### PR TITLE
Access to Latest Page Updates for users with admin.pages.list privilege

### DIFF
--- a/themes/grav/templates/partials/dashboard-pages.html.twig
+++ b/themes/grav/templates/partials/dashboard-pages.html.twig
@@ -1,4 +1,4 @@
-{% if authorize(['admin.pages', 'admin.super']) %}
+{% if authorize(['admin.pages.list', 'admin.pages', 'admin.super']) %}
     <div id="latest">
         <div class="button-bar">
             <a class="button" href="{{ admin_route('/pages') }}"><i class="fa fa-fw fa-file-text-o"></i>{{ "PLUGIN_ADMIN.MANAGE_PAGES"|t }}</a>
@@ -15,6 +15,4 @@
         {% endfor %}
         </table>
     </div>
-{% else %}
-    <div class="padding">You don't have sufficient access to view the dashboard...</div>
 {% endif %}


### PR DESCRIPTION
This mod allows users with admin.pages.list privilege to see
Latest Page Updates on Dashboard (user can see page list so
there is no point in disallowing them to see list of recently
updated pages).

It also removes unnecessary and misleading message about dashboard
access denied instead of Latest Page Updates area (user still may
have access to stats on Dashboard for example; printing such
messages should be avoided for cleaner UI also).

Author-Change-Id: IB#1120576