### PR TITLE
Enable RTL mode for CodeMirror editor

### DIFF
--- a/themes/grav/css/codemirror/codemirror.css
+++ b/themes/grav/css/codemirror/codemirror.css
@@ -263,6 +263,8 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
 
 .CodeMirror-widget {}
 
+.CodeMirror-rtl pre { direction: rtl; }
+
 .CodeMirror-code {
   outline: none;
 }


### PR DESCRIPTION
Background: CodeMirror 5 has the capability of being switched to RTL on the fly (cf. https://codemirror.net/5/demo/bidi.html), using the `setOption` method on the editor object, e.g. `editor.setOption("direction", "rtl")`.

As mentioned [here](https://github.com/getgrav/grav-plugin-admin/issues/1925#issuecomment-731453269), the Editor instance is exposed in the Grav admin interface. So it should be possible to switch it to RTL as above. 

However, this does not work, seemingly because of one missing line of CSS. For although the CodeMirror JS files, as far as I can tell, are pulled in as a dependency and include the RTL-enabling changes made in [this commit](https://github.com/codemirror/codemirror5/commit/3c18925bc667a5f0c9580de846ec4deaced6abd5), `codemirror.css` is hardcoded based on a version from before the commit, and so is missing [this addition](https://github.com/codemirror/codemirror5/commit/3c18925bc667a5f0c9580de846ec4deaced6abd5#diff-af6b8871a31183cf87b727db7afb5c0a2800f27df16280eaa0f4e8d30fe6b111). 

The attached commit corrects this accident of history, and provides the option for a plugin or a future feature addition to the Admin plugin to enable the RTL feature of the editor.