### PR TITLE
Update fieldset.html.twig

### DIFF
--- a/themes/grav/templates/forms/fields/fieldset/fieldset.html.twig
+++ b/themes/grav/templates/forms/fields/fieldset/fieldset.html.twig
@@ -49,7 +49,7 @@
 
           {% block group %}
               {% if field.text %}
-                {{ field.markdown ? field.text|t|markdown : ('<p>' ~ field.t ~ '</p>')|raw }}
+                {{ field.markdown ? field.text|t|markdown : ('<p>' ~ field.text|t ~ '</p>')|raw }}
               {% endif %}
 
               {% if field.fields %}


### PR DESCRIPTION
Fix `fieldset.text` not rendering when `markdown` isn't set, or is falsy.