### PR TITLE
fix more than one file upload field

### DIFF
--- a/themes/grav/scss/template/_admin.scss
+++ b/themes/grav/scss/template/_admin.scss
@@ -332,7 +332,7 @@ $content-padding: 1.5rem;
         object-fit: cover;
     }
 
-    & ~ .block-file {
+    & + .block-file {
         margin-top: -5rem !important;
     }
 }


### PR DESCRIPTION
Sometimes you just can't add new `file`field to `User`

![image](https://user-images.githubusercontent.com/7556290/190879345-d9f254b4-a4f4-4703-95eb-524b56b91003.png)

because of one symbol 😆 

Not `~` General Sibling Selector (selects all next elements that are siblings of a specified element) but `+` Adjacent Sibling Selector (selects all elements that are the adjacent siblings of a specified element).

