### PR TITLE
Hide the dashboard-notifications and dashboard-feed widgets by default

### DIFF
--- a/admin.yaml
+++ b/admin.yaml
@@ -15,8 +15,8 @@ dashboard:
 widgets_display:
   dashboard-maintenance: true
   dashboard-statistics: true
-  dashboard-notifications: true
-  dashboard-feed: true
+  dashboard-notifications: false
+  dashboard-feed: false
   dashboard-pages: true
 pages:
   show_parents: both


### PR DESCRIPTION
Just a proposal to not advertise these didn't get any recent and regular updates.