### PR TITLE
Set document language to user preference

### DIFF
--- a/themes/grav/templates/partials/base-root.html.twig
+++ b/themes/grav/templates/partials/base-root.html.twig
@@ -1,6 +1,6 @@
 {% if uri.extension() == 'json' %}{% include 'default.json.twig' %}{% else %}
     <!DOCTYPE html>
-    <html lang="en">
+    <html lang="{{ user.language|default( 'en' ) }}">
     <head>
     {% block head %}
         <meta charset="utf-8" />


### PR DESCRIPTION
Firefox Nightly now has a translation feature included. So I noticed, that it offered to translate the grav admin into my mother tongue, even  though I already set it as the admin interface language. The whole admin was hard coded to english.