### PR TITLE
Added sublabel, label classes and icon help to list field

### DIFF
--- a/themes/grav/templates/forms/field.html.twig
+++ b/themes/grav/templates/forms/field.html.twig
@@ -60,11 +60,6 @@
                     {{ field.validate.required in ['on', 'true', 1] ? '<span class="required">*</span>' }}
                 {% endblock %}
                 </label>
-                {% if field.description %}
-                <div class="form-extra-wrapper">
-                    <span class="form-description">{{ field.description|t|markdown(false)|raw }}</span>
-                </div>
-                {% endif %}
                 {% if field.sublabel %}
                 <div class="form-sublabel">
                     {% if field.markdown %}

--- a/themes/grav/templates/forms/field.html.twig
+++ b/themes/grav/templates/forms/field.html.twig
@@ -42,7 +42,7 @@
                         <label for="toggleable_{{ field.name }}"></label>
                     </span>
                 {% endif %}
-                <label{{ (toggleable ? ' class="toggleable" for="toggleable_' ~ field.name ~ '"')|raw }}>
+               <label{{ (field.toggleable ? ' class="toggleable ' ~ field.classes ~ '" for="toggleable_' ~ field.name ~ '"' : ' class="' ~ field.classes ~ '"')|raw }}>
                 {% block label %}
                     {% if field.help %}
                         {% if field.markdown %}
@@ -60,6 +60,11 @@
                     {{ field.validate.required in ['on', 'true', 1] ? '<span class="required">*</span>' }}
                 {% endblock %}
                 </label>
+                {% if field.description %}
+                <div class="form-extra-wrapper">
+                    <span class="form-description">{{ field.description|t|markdown(false)|raw }}</span>
+                </div>
+                {% endif %}
                 {% if field.sublabel %}
                 <div class="form-sublabel">
                     {% if field.markdown %}

--- a/themes/grav/templates/forms/fields/list/list.html.twig
+++ b/themes/grav/templates/forms/fields/list/list.html.twig
@@ -21,9 +21,18 @@
         {% endif %}
         <label{{ (field.toggleable ? ' class="toggleable" for="toggleable_' ~ field.name ~ '"')|raw }}>
             {% if field.help %}
-            <span class="hint--bottom" data-hint="{{ field.help|t }}">{{ field.label|t }}</span>
+                {% if field.markdown %}
+                    <span class="hint--bottom" data-hint="{{ field.help|t|markdown(false) }}">{{ field.label|t|markdown(false)|raw }} <i class="hint-icon fa fa-question-circle" aria-hidden="true"></i></span>
+                {% else %}
+                    <span class="hint--bottom" data-hint="{{ field.help|t }}">{{ field.label|t|raw }} <i class="hint-icon fa fa-question-circle" aria-hidden="true"></i></span>
+                {% endif %}
             {% else %}
             {{ field.label|t }}
+            {% endif %}
+            {% if field.description %}
+            <div class="form-extra-wrapper">
+                <span class="form-description">{{ field.description|t|markdown(false)|raw }}</span>
+            </div>
             {% endif %}
             {{ field.validate.required in ['on', 'true', 1] ? '<span class="required">*</span>' }}
         </label>
@@ -185,4 +194,3 @@
         </div>
     </div>
 {% endblock %}
-

--- a/themes/grav/templates/forms/fields/list/list.html.twig
+++ b/themes/grav/templates/forms/fields/list/list.html.twig
@@ -19,23 +19,23 @@
                 <label for="toggleable_{{ field.name }}"></label>
             </span>
         {% endif %}
-        <label{{ (field.toggleable ? ' class="toggleable" for="toggleable_' ~ field.name ~ '"')|raw }}>
+        <label{{ (field.toggleable ? ' class="toggleable ' ~ field.classes ~ '"' : ' class="' ~ field.classes ~ '"')|raw }} for="toggleable_{{ field.name }}">
             {% if field.help %}
-                {% if field.markdown %}
-                    <span class="hint--bottom" data-hint="{{ field.help|t|markdown(false) }}">{{ field.label|t|markdown(false)|raw }} <i class="hint-icon fa fa-question-circle" aria-hidden="true"></i></span>
-                {% else %}
-                    <span class="hint--bottom" data-hint="{{ field.help|t }}">{{ field.label|t|raw }} <i class="hint-icon fa fa-question-circle" aria-hidden="true"></i></span>
-                {% endif %}
+            <span class="hint--bottom" data-hint="{{ field.help|t }}">{{ field.label|t }}</span>
             {% else %}
             {{ field.label|t }}
             {% endif %}
-            {% if field.description %}
-            <div class="form-extra-wrapper">
-                <span class="form-description">{{ field.description|t|markdown(false)|raw }}</span>
-            </div>
-            {% endif %}
             {{ field.validate.required in ['on', 'true', 1] ? '<span class="required">*</span>' }}
         </label>
+        {% if field.sublabel %}
+        <div class="form-sublabel">
+            {% if field.markdown %}
+                {{ field.sublabel|t|markdown(false)|raw }}
+            {% else %}
+                {{ field.sublabel|t|raw }}
+            {% endif %}
+        </div>
+        {% endif %}
     </div>
     <div class="form-data{% if not vertical %} block size-2-3 pure-u-2-3{% endif %}"
         {% block global_attributes %}

--- a/themes/grav/templates/forms/fields/list/list.html.twig
+++ b/themes/grav/templates/forms/fields/list/list.html.twig
@@ -19,14 +19,23 @@
                 <label for="toggleable_{{ field.name }}"></label>
             </span>
         {% endif %}
-        <label{{ (field.toggleable ? ' class="toggleable ' ~ field.classes ~ '"' : ' class="' ~ field.classes ~ '"')|raw }} for="toggleable_{{ field.name }}">
+        <label{{ (field.toggleable ? ' class="toggleable ' ~ field.classes ~ '" for="toggleable_' ~ field.name ~ '"' : ' class="' ~ field.classes ~ '"')|raw }}>
             {% if field.help %}
-            <span class="hint--bottom" data-hint="{{ field.help|t }}">{{ field.label|t }}</span>
+                {% if field.markdown %}
+                    <span class="hint--bottom" data-hint="{{ field.help|t|markdown(false) }}">{{ field.label|t|markdown(false)|raw }} <i class="hint-icon fa fa-question-circle" aria-hidden="true"></i></span>
+                {% else %}
+                    <span class="hint--bottom" data-hint="{{ field.help|t }}">{{ field.label|t|raw }} <i class="hint-icon fa fa-question-circle" aria-hidden="true"></i></span>
+                {% endif %}
             {% else %}
             {{ field.label|t }}
             {% endif %}
             {{ field.validate.required in ['on', 'true', 1] ? '<span class="required">*</span>' }}
         </label>
+        {% if field.description %}
+        <div class="form-extra-wrapper">
+            <span class="form-description">{{ field.description|t|markdown(false)|raw }}</span>
+        </div>
+        {% endif %}
         {% if field.sublabel %}
         <div class="form-sublabel">
             {% if field.markdown %}


### PR DESCRIPTION
With this modification, list field labels can have a description (with markdown support), a sublabel, or a help icon, or all of them. 
Field classes are also added