### PR TITLE
fix(force_ssl): use scheme instead of server https index

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -396,9 +396,10 @@ class AdminPlugin extends Plugin
 
         // Force SSL with redirect if required
         if ($config->get('system.force_ssl')) {
-            if (!isset($_SERVER['HTTPS']) || strtolower($_SERVER['HTTPS']) !== 'on') {
+            $scheme = $this->uri->scheme(true);
+            if ($scheme !== 'https') {
                 Admin::DEBUG && Admin::addDebugMessage('Admin SSL forced on, redirect');
-                $url = 'https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+                $url = 'https://' . $this->uri->host() . $this->uri->uri();
                 $this->grav->redirect($url);
             }
         }


### PR DESCRIPTION
using some proxy / load balancer (openbsd relayd -> httpd -> php-fpm) may not properly set server https index, thus leading to infinite redirections on force_ssl parameter set to true

align https detection with grav-core code:

https://github.com/getgrav/grav/blob/a1c116dd82c761ecf9800e412fcd9159722ad769/system/src/Grav/Common/Service/PagesServiceProvider.php#L72-L78

slightly related to #1479 (came across this portion of code by searching using force_ssl keyword and stumbled upon this issue)