### PR TITLE
Improve log date handling in tools-logs.html.twig

### DIFF
--- a/themes/grav/templates/partials/tools-logs.html.twig
+++ b/themes/grav/templates/partials/tools-logs.html.twig
@@ -53,7 +53,11 @@
             <tbody>
                 {% for log in logs %}
                 <tr>
-                    <td class="date" title="{{ log.date|date('r') }}">{{ log.date|date }}</td>
+                    {% if log.date %}
+                        <td class="date" title="{{ log.date|date('r') }}">{{ log.date|date }}</td>
+                    {% else %}
+                        <td class="date" title=""></td>
+                    {% endif %}
                     <td class="level"><span class="badge {{ log.level|lower }}">{{ log.level }}</span></td>
                     <td class="message">{{ log.message }}</td>
                     {% if verbose %}


### PR DESCRIPTION
This pull request is part of the fix for https://github.com/getgrav/grav-plugin-admin/issues/2468
The main part is this pull request https://github.com/getgrav/grav/pull/4007

To avoid the output of the current date if none date was parsed from the logfile, a conditional check was added.