### PR TITLE
Fix file field preview URLs and invalid thumbnail requests

### DIFF
--- a/themes/grav/app/forms/fields/files.js
+++ b/themes/grav/app/forms/fields/files.js
@@ -155,8 +155,18 @@ export default class FilesField {
             const file = target.parent('.dz-preview').find('.dz-filename');
             const filename = encodeURI(file.text());
 
-            const URL = Object.keys(value).filter((key) => value[key].name === filename).shift();
-            target.attr('href', `${config.base_url_simple}/${URL}`);
+            const key = Object.keys(value).find((key) => {
+                const item = value[key];
+                return item && encodeURI(item.name) === filename;
+            });
+
+            if (!key) {
+                return;
+            }
+
+            const item = value[key];
+            const URL = item.image_url || item.thumb_url || `${config.base_url_simple}/${key}`;
+            target.attr('href', URL);
         });
 
     }
@@ -183,7 +193,6 @@ export default class FilesField {
             dropzone.options.addedfile.call(dropzone, mock);
             if (mock.type.match(/^image\//)) {
                 dropzone.options.thumbnail.call(dropzone, mock, data.path);
-                dropzone.createThumbnailFromUrl(mock, data.path);
             }
 
             file.remove();


### PR DESCRIPTION
## Summary

Fix two issues in the Classic Admin `FilesField` used by blueprint/Flex file fields:

- Prefer the stored `image_url` / `thumb_url` when building the **View** link, while keeping the existing JSON key behavior as a backward-compatible fallback.
- Stop calling `Dropzone#createThumbnailFromUrl()` with an incompatible signature after the thumbnail has already been assigned.

## Problem

File values can be keyed by filename while exposing their actual public URL through `image_url` and `thumb_url`. The current handler assumes the JSON key is always a URL, so a value keyed as `monkey-1.jpg` produces `/monkey-1.jpg` instead of its stored media URL.

The existing `createThumbnailFromUrl(mock, data.path)` call is also incompatible with Dropzone 5.9.3. Its second argument is treated as the thumbnail width, while the method reads the image URL from `mock.dataURL`. Since `mock.dataURL` is unset, Chrome requests an image named `undefined`. The preceding `thumbnail` callback already assigns `data.path`, so the call is redundant.

The filename comparison now encodes both sides consistently, which also supports filenames containing spaces.

## Verification

- `node --check themes/grav/app/forms/fields/files.js`
- `yarn prod` — production Webpack build completed successfully (only the existing asset-size warnings)
- Browser reproduction with a Flex file field:
  - image and audio View links resolve to their stored media URLs and return HTTP 200
  - existing image preview remains visible
  - no `/undefined` thumbnail request is generated by `FilesField`

This targets Classic Admin / Grav 1.7. Admin 2.0 uses a different implementation.